### PR TITLE
サービスを登録するAPIを作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "jbuilder", "~> 2.7"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.2", require: false
+gem "rails-i18n"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3.2)
       actionpack (= 6.0.3.2)
       activesupport (= 6.0.3.2)
@@ -203,6 +206,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
+  rails-i18n
   rubocop
   rubocop-performance
   rubocop-rails

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class ServicesController < ApplicationController
+  def create
+    @service = Service.new(service_params)
+    if @service.save
+      redirect_to root_path
+    else
+      respond_to do |format|
+        format.json { render json: @service.errors }
+      end
+    end
+  end
+
+  private
+    def service_params
+      params.require(:service).permit(
+        :name,
+        :description,
+        :plan,
+        :price,
+        :renewed_on,
+        :remind_on,
+      )
+    end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Service < ApplicationRecord
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class Service < ApplicationRecord
+  enum plan: { monthly: 0, yearly: 1 }
+
+  validates :name, presence: true
+  validates :plan, presence: true
+  validates :price, numericality: { only_integer: true, allow_blank: true }
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Home#index</h1>
+<p>Find me in app/views/home/index.html.erb</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,7 @@ module PrebillReact
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
+    config.i18n.default_locale = :ja
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,18 @@
+ja:
+  activerecord:
+    models:
+      service: サービス
+    attributes:
+      service:
+        name: サービス名
+        plan: プラン
+        renewed_on: 更新日
+        remind_on: 通知日
+        description: メモ
+        created_at: 作成日時
+        updated_at: 更新日時
+    enums:
+      service:
+        plan:
+          monthly: 月額
+          yearly: 年額

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  root to: "home#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@
 
 Rails.application.routes.draw do
   root to: "home#index"
+  resources :services, only: %i(create)
 end

--- a/db/migrate/20200622065734_create_services.rb
+++ b/db/migrate/20200622065734_create_services.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateServices < ActiveRecord::Migration[6.0]
+  def change
+    create_table :services do |t|
+      t.string :name, null: false
+      t.text :description
+      t.integer :plan, default: 0, null: false
+      t.integer :price
+      t.date :renewed_on
+      t.date :remind_on
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_06_22_065734) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "services", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "description"
+    t.integer "plan", default: 0, null: false
+    t.integer "price"
+    t.date "renewed_on"
+    t.date "remind_on"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+end


### PR DESCRIPTION
ref: #3 

## 概要

- Serviceモデルを作成
- バリデーションを定義
- サービスを登録するAPIを作成
- 登録成功時のリダイレクトが確認できるようにトップページを作成(HomeController)
- rails-i18nを追加し、日本語の辞書ファイルを作成

### やらなかったこと

- Flashメッセージの表示
    - 次のissue #18 にて実装予定