### PR TITLE
サービス更新に関するフロントの処理を実装

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -31,7 +31,7 @@ class ServicesController < ApplicationController
       head :ok
     else
       respond_to do |format|
-        format.json { render json @service.errors.full_messages, status: 422 }
+        format.json { render json: @service.errors.full_messages, status: 422 }
       end
     end
   end

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ServicesController < ApplicationController
-  before_action :load_service, only: %i(update)
+  before_action :load_service, only: %i(edit update)
 
   def new
   end
@@ -15,6 +15,13 @@ class ServicesController < ApplicationController
       respond_to do |format|
         format.json { render json: @service.errors.full_messages, status: 422 }
       end
+    end
+  end
+
+  def edit
+    respond_to do |format|
+      format.html
+      format.json { render json: @service }
     end
   end
 

--- a/app/javascript/components/EditService.js
+++ b/app/javascript/components/EditService.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ServiceForm from './ServiceForm';
+import getCsrfToken from '../helpers/getCsrfToken';
+
+class EditService extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      service: null,
+      errorMessages: [],
+    };
+
+    this.updateService = this.updateService.bind(this);
+  }
+
+  componentDidMount() {
+    const { serviceId } = this.props;
+    fetch(`/services/${serviceId}/edit.json`, {
+      method: 'GET',
+      credentials: 'same-origin',
+    })
+      .then((response) => {
+        response.json()
+          .then((service) => {
+            this.setState({ service });
+          });
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+
+  updateService(editedService) {
+    const { serviceId } = this.props;
+    fetch(`/services/${serviceId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'X-CSRF-Token': getCsrfToken(),
+      },
+      credentials: 'same-origin',
+      body: JSON.stringify(editedService),
+    })
+      .then((response) => {
+        if (response.ok) {
+          window.location.href = '/';
+        } else {
+          response.json()
+            .then((errorMessages) => {
+              this.setState({ errorMessages });
+            });
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+
+  render() {
+    const { errorMessages, service } = this.state;
+
+    if (service === null) return null;
+
+    return (
+      <div>
+        <ServiceForm
+          service={service}
+          onSubmit={this.updateService}
+          errorMessages={errorMessages}
+        />
+      </div>
+    );
+  }
+}
+
+export default EditService;
+
+EditService.propTypes = {
+  serviceId: PropTypes.string,
+};
+
+EditService.defaultProps = {
+  serviceId: '',
+};

--- a/app/javascript/components/ServiceForm.js
+++ b/app/javascript/components/ServiceForm.js
@@ -147,7 +147,14 @@ class ServiceForm extends React.Component {
 export default ServiceForm;
 
 ServiceForm.propTypes = {
-  service: PropTypes.objectOf(PropTypes.string),
+  service: PropTypes.shape({
+    name: PropTypes.string,
+    plan: PropTypes.string,
+    price: PropTypes.number,
+    renewed_on: PropTypes.string,
+    remind_on: PropTypes.string,
+    description: PropTypes.string,
+  }),
   onSubmit: PropTypes.func.isRequired,
   errorMessages: PropTypes.arrayOf(PropTypes.string),
 };
@@ -156,7 +163,7 @@ ServiceForm.defaultProps = {
   service: {
     name: '',
     plan: 'monthly',
-    price: '',
+    price: 0,
     renewed_on: '',
     remind_on: '',
     description: '',

--- a/app/javascript/components/ServiceForm.js
+++ b/app/javascript/components/ServiceForm.js
@@ -37,7 +37,7 @@ class ServiceForm extends React.Component {
   }
 
   render() {
-    const { plan } = this.state;
+    const { service } = this.state;
     const { errorMessages } = this.props;
 
     return (
@@ -56,6 +56,7 @@ class ServiceForm extends React.Component {
                   id="service_name"
                   name="name"
                   placeholder="サービス名"
+                  value={service.name}
                   onChange={this.handleInputChange}
                 />
               </label>
@@ -67,7 +68,7 @@ class ServiceForm extends React.Component {
                   <select
                     name="plan"
                     id="service_plan"
-                    value={plan}
+                    value={service.plan}
                     onChange={this.handleInputChange}
                     className="form-item__select"
                   >
@@ -84,6 +85,7 @@ class ServiceForm extends React.Component {
                     className="form-item__text-input"
                     id="service_price"
                     name="price"
+                    value={service.price}
                     onChange={this.handleInputChange}
                   />
                 </label>
@@ -97,6 +99,7 @@ class ServiceForm extends React.Component {
                   className="form-item__text-input"
                   id="service_renewed_on"
                   name="renewed_on"
+                  value={service.renewed_on}
                   onChange={this.handleInputChange}
                 />
               </label>
@@ -109,6 +112,7 @@ class ServiceForm extends React.Component {
                   className="form-item__text"
                   id="service_remind_on"
                   name="remind_on"
+                  value={service.remind_on}
                   onChange={this.handleInputChange}
                 />
               </label>
@@ -120,6 +124,7 @@ class ServiceForm extends React.Component {
                   name="description"
                   id="service_description"
                   className="form-item__textarea"
+                  value={service.description}
                   onChange={this.handleInputChange}
                 />
               </label>

--- a/app/javascript/packs/services/edit.js
+++ b/app/javascript/packs/services/edit.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { render } from 'react-dom';
+import EditService from '../../components/EditService';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const el = document.querySelector('#root');
+  const { serviceId } = el.dataset;
+  render(
+    <EditService serviceId={serviceId} />,
+    el,
+  );
+});

--- a/app/views/services/edit.html.erb
+++ b/app/views/services/edit.html.erb
@@ -1,0 +1,2 @@
+<%= javascript_pack_tag 'services/edit' %>
+<div id="root" data-service-id=<%= "#{@service.id}" %>></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,5 @@ Rails.application.routes.draw do
     resources :flash, only: %i(index)
   end
   root to: "home#index"
-  resources :services, only: %i(new create update)
+  resources :services, only: %i(new create edit update)
 end


### PR DESCRIPTION
ref: #19 

## 概要

- サービスの編集ページを作成
    - edit.html.erbテンプレートファイルを追加
    - EditServiceコンポーネントを作成
- 登録済みのデータを取得してServiceFormコンポーネントに渡す際、priceについてデータ型が一致しないと警告が表示されたため、propsとしてnumberを受け取るように型チェックの定義を修正
- updateアクションでエラーメッセージを受け取ることができていなかったのを修正

### 画像

[![Image from Gyazo](https://i.gyazo.com/2117d49b1245c05bbb81c08bf5cad1ec.gif)](https://gyazo.com/2117d49b1245c05bbb81c08bf5cad1ec)