### PR TITLE
サービスの削除に関するフロントの処理を実装

### DIFF
--- a/app/javascript/components/Flash.js
+++ b/app/javascript/components/Flash.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class Flash extends React.Component {
   constructor(props) {
@@ -56,3 +57,7 @@ class Flash extends React.Component {
 }
 
 export default Flash;
+
+Flash.propTypes = {
+  services: PropTypes.arrayOf(PropTypes.object).isRequired,
+};

--- a/app/javascript/components/Flash.js
+++ b/app/javascript/components/Flash.js
@@ -9,6 +9,17 @@ class Flash extends React.Component {
   }
 
   componentDidMount() {
+    this.fetchFlash();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { services } = this.props;
+    if (services !== prevProps.services) {
+      this.fetchFlash();
+    }
+  }
+
+  fetchFlash() {
     fetch('/api/flash', {
       method: 'GET',
     })

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const ServiceItem = ({ service }) => (
+const ServiceItem = ({ service, onDelete }) => (
   <div className="list">
     <div className="list--display">
       <div className="list-item col-lg">{service.name}</div>
@@ -22,7 +22,7 @@ const ServiceItem = ({ service }) => (
             <a href={`services/${service.id}/edit`} className="btn--full btn--sm btn--secondary">修正</a>
           </div>
           <div className="list__action">
-            {/* TODO 削除ボタンを実装 */}
+            <button type="button" onClick={() => onDelete(service.id)}>削除</button>
           </div>
         </div>
       </div>

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -42,6 +42,7 @@ ServiceItem.propTypes = {
     remind_on: PropTypes.string,
     description: PropTypes.string,
   }),
+  onDelete: PropTypes.func.isRequired,
 };
 
 ServiceItem.defaultProps = {

--- a/app/javascript/components/UsingServices.js
+++ b/app/javascript/components/UsingServices.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ServiceList from './ServiceList';
 import ServiceItem from './ServiceItem';
 
@@ -19,3 +20,8 @@ const UsingServices = ({ services, onDelete }) => (
 );
 
 export default UsingServices;
+
+UsingServices.propTypes = {
+  services: PropTypes.arrayOf(PropTypes.object).isRequired,
+  onDelete: PropTypes.func.isRequired,
+};

--- a/app/javascript/components/UsingServices.js
+++ b/app/javascript/components/UsingServices.js
@@ -2,51 +2,20 @@ import React from 'react';
 import ServiceList from './ServiceList';
 import ServiceItem from './ServiceItem';
 
-class UsingServices extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      services: null,
-    };
-  }
-
-  componentDidMount() {
-    fetch('/services.json', {
-      method: 'GET',
-      credentials: 'same-origin',
-    })
-      .then((response) => {
-        response.json()
-          .then((services) => {
-            this.setState({ services });
-          });
-      })
-      .catch((error) => {
-        console.error(error);
-      });
-  }
-
-  render() {
-    const { services } = this.state;
-
-    if (services === null) {
-      return null;
-    }
-
-    return (
-      <div className="page-body">
-        <h3 className="page-body__header">利用中のサービス</h3>
-        <div className="page-body__actions">
-          <a href="/services/new">新規登録</a>
-        </div>
-        <div className="page-body__inner">
-          <ServiceList>
-            {services.map((service) => <ServiceItem service={service} key={service.id} />)}
-          </ServiceList>
-        </div>
-      </div>
-    );
-  }
-}
+const UsingServices = ({ services, onDelete }) => (
+  <div className="page-body">
+    <h3 className="page-body__header">利用中のサービス</h3>
+    <div className="page-body__actions">
+      <a href="/services/new">新規登録</a>
+    </div>
+    <div className="page-body__inner">
+      <ServiceList>
+        {services.map((service) => (
+          <ServiceItem service={service} onDelete={onDelete} key={service.id} />
+        ))}
+      </ServiceList>
+    </div>
+  </div>
+);
 
 export default UsingServices;

--- a/app/javascript/packs/services/index.js
+++ b/app/javascript/packs/services/index.js
@@ -2,13 +2,73 @@ import React from 'react';
 import { render } from 'react-dom';
 import UsingServices from '../../components/UsingServices';
 import Flash from '../../components/Flash';
+import getCsrfToken from '../../helpers/getCsrfToken';
 
-const Index = () => (
-  <>
-    <Flash />
-    <UsingServices />
-  </>
-);
+class Index extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      services: null,
+    };
+
+    this.deleteService = this.deleteService.bind(this);
+  }
+
+  componentDidMount() {
+    fetch('/services.json', {
+      method: 'GET',
+      credentials: 'same-origin',
+    })
+      .then((response) => {
+        response.json()
+          .then((services) => {
+            this.setState({ services });
+          });
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+
+  deleteService(serviceId) {
+    const confirm = window.confirm('本当に削除しますか?');
+    if (confirm) {
+      fetch(`/services/${serviceId}`, {
+        method: 'DELETE',
+        headers: {
+          'X-CSRF-TOKEN': getCsrfToken(),
+        },
+        credentials: 'same-origin',
+      })
+        .then((response) => {
+          if (response.ok) {
+            const { services } = this.state;
+            this.setState({
+              services: services.filter((service) => serviceId !== service.id),
+            });
+          }
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+    }
+  }
+
+  render() {
+    const { services } = this.state;
+
+    if (services === null) {
+      return null;
+    }
+
+    return (
+      <>
+        <Flash services={services} />
+        <UsingServices onDelete={this.deleteService} services={services} />
+      </>
+    );
+  }
+}
 
 document.addEventListener('DOMContentLoaded', () => {
   render(


### PR DESCRIPTION
## 概要

- UsingServicesコンポーネントに定義していたサービス一覧の取得をIndexコンポーネントで取得するように修正
    - サービスの削除時にもFlashメッセージを表示させるため
        - サービスの作成/編集はリダイレクトがあったため、FlashコンポーネントがAPIからFlashを取得することができたが、サービスの削除はリダイレクトがない(サービス削除後も削除前と同じサービス一覧ページが表示される)
        - Reactが保持しているサービスのStateを変更させることでページ上からサービスを削除するようにしているため、この状態の変更をFlashが検知できるようにする必要があった
    - FlashコンポーネントにcomponentDidUpdateライフサイクルを定義し、Flashが受け取ったpropsの状態が変更されたときに再度Fetchする処理が走るようにした
        - Fetchする処理はfetchFlash()としてまとめた
- ServiceItemコンポーネントに削除ボタンを設置し、ボタンが押下されて確認ダイアログでOKが選択されたときにサービスが削除される機能を追加
- UsingServicesコンポーネントは状態を管理する必要がなくなったため、関数コンポーネントとして定義し直した
- 各コンポーネントに型チェックの定義を追加・修正

## 画面のスクリーンショット

サービスを削除し、Flashメッセージが表示される(更新後にはFlashは表示されない)

[![Image from Gyazo](https://i.gyazo.com/aad5569d0bbea632f1252198c508b683.gif)](https://gyazo.com/aad5569d0bbea632f1252198c508b683)
