### PR TITLE
利用金額をトップページに表示する機能を作成

### DIFF
--- a/app/javascript/components/TotalPriceItem.js
+++ b/app/javascript/components/TotalPriceItem.js
@@ -8,7 +8,7 @@ const TotalPriceItem = ({ amountPrice, color, children }) => (
         {children}
       </div>
       <div className="card__amount">
-        {amountPrice()}
+        {amountPrice}
       </div>
     </div>
   </div>
@@ -17,7 +17,7 @@ const TotalPriceItem = ({ amountPrice, color, children }) => (
 export default TotalPriceItem;
 
 TotalPriceItem.propTypes = {
-  amountPrice: PropTypes.func.isRequired,
+  amountPrice: PropTypes.number.isRequired,
   color: PropTypes.string.isRequired,
   children: PropTypes.string.isRequired,
 };

--- a/app/javascript/components/TotalPriceItem.js
+++ b/app/javascript/components/TotalPriceItem.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const TotalPriceItem = ({ amountPrice, color, children }) => (
+  <div className={`card card--${color}`}>
+    <div className="card__body">
+      <div className="card__title">
+        {children}
+      </div>
+      <div className="card__amount">
+        {amountPrice()}
+      </div>
+    </div>
+  </div>
+);
+
+export default TotalPriceItem;

--- a/app/javascript/components/TotalPriceItem.js
+++ b/app/javascript/components/TotalPriceItem.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const TotalPriceItem = ({ amountPrice, color, children }) => (
   <div className={`card card--${color}`}>
@@ -14,3 +15,9 @@ const TotalPriceItem = ({ amountPrice, color, children }) => (
 );
 
 export default TotalPriceItem;
+
+TotalPriceItem.propTypes = {
+  amountPrice: PropTypes.func.isRequired,
+  color: PropTypes.string.isRequired,
+  children: PropTypes.string.isRequired,
+};

--- a/app/javascript/components/TotalPriceList.js
+++ b/app/javascript/components/TotalPriceList.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import TotalPriceItem from './TotalPriceItem';
-import { annualTotalAmount, monthlyAverageAmount } from '../helpers/service';
+import { calcAnnualTotalAmount, monthlyAverageAmount } from '../helpers/service';
 
 const TotalPriceList = ({ services }) => (
   <div className="card-container">
     <TotalPriceItem color="yellow" amountPrice={() => monthlyAverageAmount(services)}>
       月平均利用額
     </TotalPriceItem>
-    <TotalPriceItem color="green" amountPrice={() => annualTotalAmount(services)}>
+    <TotalPriceItem color="green" amountPrice={() => calcAnnualTotalAmount(services)}>
       年間合計額
     </TotalPriceItem>
   </div>

--- a/app/javascript/components/TotalPriceList.js
+++ b/app/javascript/components/TotalPriceList.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import TotalPriceItem from './TotalPriceItem';
+import { annualTotalAmount, monthlyAverageAmount } from '../helpers/service';
+
+const TotalPriceList = ({ services }) => (
+  <div className="card-container">
+    <TotalPriceItem color="yellow" amountPrice={() => monthlyAverageAmount(services)}>
+      月平均利用額
+    </TotalPriceItem>
+    <TotalPriceItem color="green" amountPrice={() => annualTotalAmount(services)}>
+      年間合計額
+    </TotalPriceItem>
+  </div>
+);
+
+export default TotalPriceList;

--- a/app/javascript/components/TotalPriceList.js
+++ b/app/javascript/components/TotalPriceList.js
@@ -5,10 +5,10 @@ import { calcAnnualTotalAmount, calcMonthlyAverageAmount } from '../helpers/serv
 
 const TotalPriceList = ({ services }) => (
   <div className="card-container">
-    <TotalPriceItem color="yellow" amountPrice={() => calcMonthlyAverageAmount(services)}>
+    <TotalPriceItem color="yellow" amountPrice={calcMonthlyAverageAmount(services)}>
       月平均利用額
     </TotalPriceItem>
-    <TotalPriceItem color="green" amountPrice={() => calcAnnualTotalAmount(services)}>
+    <TotalPriceItem color="green" amountPrice={calcAnnualTotalAmount(services)}>
       年間合計額
     </TotalPriceItem>
   </div>

--- a/app/javascript/components/TotalPriceList.js
+++ b/app/javascript/components/TotalPriceList.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import TotalPriceItem from './TotalPriceItem';
-import { calcAnnualTotalAmount, monthlyAverageAmount } from '../helpers/service';
+import { calcAnnualTotalAmount, calcMonthlyAverageAmount } from '../helpers/service';
 
 const TotalPriceList = ({ services }) => (
   <div className="card-container">
-    <TotalPriceItem color="yellow" amountPrice={() => monthlyAverageAmount(services)}>
+    <TotalPriceItem color="yellow" amountPrice={() => calcMonthlyAverageAmount(services)}>
       月平均利用額
     </TotalPriceItem>
     <TotalPriceItem color="green" amountPrice={() => calcAnnualTotalAmount(services)}>

--- a/app/javascript/components/TotalPriceList.js
+++ b/app/javascript/components/TotalPriceList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import TotalPriceItem from './TotalPriceItem';
 import { annualTotalAmount, monthlyAverageAmount } from '../helpers/service';
 
@@ -12,5 +13,9 @@ const TotalPriceList = ({ services }) => (
     </TotalPriceItem>
   </div>
 );
+
+TotalPriceList.propTypes = {
+  services: PropTypes.arrayOf(PropTypes.object).isRequired,
+};
 
 export default TotalPriceList;

--- a/app/javascript/helpers/service.js
+++ b/app/javascript/helpers/service.js
@@ -5,6 +5,12 @@ const totalAmount = (services, plan) => {
   );
 };
 
-export const annualTotalAmount = (services) => totalAmount(services, 'yearly') + (totalAmount(services, 'monthly') * 12);
+export const annualTotalAmount = (services) => {
+  const annualTotalPrice = totalAmount(services, 'yearly') + (totalAmount(services, 'monthly') * 12);
+  return Math.floor(annualTotalPrice);
+};
 
-export const monthlyAverageAmount = (services) => annualTotalAmount(services) / 12;
+export const monthlyAverageAmount = (services) => {
+  const monthlyAveragePrice = annualTotalAmount(services) / 12;
+  return Math.floor(monthlyAveragePrice);
+};

--- a/app/javascript/helpers/service.js
+++ b/app/javascript/helpers/service.js
@@ -10,7 +10,7 @@ export const calcAnnualTotalAmount = (services) => {
   return Math.floor(annualTotalPrice);
 };
 
-export const monthlyAverageAmount = (services) => {
+export const calcMonthlyAverageAmount = (services) => {
   const monthlyAveragePrice = calcAnnualTotalAmount(services) / 12;
   return Math.floor(monthlyAveragePrice);
 };

--- a/app/javascript/helpers/service.js
+++ b/app/javascript/helpers/service.js
@@ -1,0 +1,10 @@
+const totalAmount = (services, plan) => {
+  const servicesByPlan = services.filter((service) => service.plan === plan);
+  return servicesByPlan.reduce(
+    (sum, currentValue) => sum + currentValue.price, 0,
+  );
+};
+
+export const annualTotalAmount = (services) => totalAmount(services, 'yearly') + (totalAmount(services, 'monthly') * 12);
+
+export const monthlyAverageAmount = (services) => annualTotalAmount(services) / 12;

--- a/app/javascript/helpers/service.js
+++ b/app/javascript/helpers/service.js
@@ -1,12 +1,12 @@
-const totalAmount = (services, plan) => {
+const calcTotalAmount = (services, plan) => {
   const servicesByPlan = services.filter((service) => service.plan === plan);
   return servicesByPlan.reduce(
-    (sum, currentValue) => sum + currentValue.price, 0,
+    (sum, service) => sum + service.price, 0,
   );
 };
 
 export const annualTotalAmount = (services) => {
-  const annualTotalPrice = totalAmount(services, 'yearly') + (totalAmount(services, 'monthly') * 12);
+  const annualTotalPrice = calcTotalAmount(services, 'yearly') + (calcTotalAmount(services, 'monthly') * 12);
   return Math.floor(annualTotalPrice);
 };
 

--- a/app/javascript/helpers/service.js
+++ b/app/javascript/helpers/service.js
@@ -5,12 +5,12 @@ const calcTotalAmount = (services, plan) => {
   );
 };
 
-export const annualTotalAmount = (services) => {
+export const calcAnnualTotalAmount = (services) => {
   const annualTotalPrice = calcTotalAmount(services, 'yearly') + (calcTotalAmount(services, 'monthly') * 12);
   return Math.floor(annualTotalPrice);
 };
 
 export const monthlyAverageAmount = (services) => {
-  const monthlyAveragePrice = annualTotalAmount(services) / 12;
+  const monthlyAveragePrice = calcAnnualTotalAmount(services) / 12;
   return Math.floor(monthlyAveragePrice);
 };

--- a/app/javascript/packs/services/index.js
+++ b/app/javascript/packs/services/index.js
@@ -3,6 +3,7 @@ import { render } from 'react-dom';
 import UsingServices from '../../components/UsingServices';
 import Flash from '../../components/Flash';
 import getCsrfToken from '../../helpers/getCsrfToken';
+import TotalPriceList from '../../components/TotalPriceList';
 
 class Index extends React.Component {
   constructor(props) {
@@ -64,6 +65,7 @@ class Index extends React.Component {
     return (
       <>
         <Flash services={services} />
+        <TotalPriceList services={services} />
         <UsingServices onDelete={this.deleteService} services={services} />
       </>
     );


### PR DESCRIPTION
ref: #15 

## 概要

- 年間合計利用額/月平均利用額を算出する関数をヘルパーに定義
    - 余りは切り捨てるようにした
- 年間合計利用額と月平均利用額を表示するTotalPriceListコンポーネントを定義
    - 両者は算出に利用する関数と表示の色のみが異なるため、共通のTotalPriceItemコンポーネントを定義し、関数や表示色はpropsとして渡すようにした
- IndexコンポーネントからTotalPriceListコンポーネントを呼び出すことでトップページに合計金額が表示されるようにした
- 表示フォーマットの整形については、別途issue #38 で対応予定

## スクリーンショット

[![Image from Gyazo](https://i.gyazo.com/0f86d31426c69c1757dd6432d965597b.png)](https://gyazo.com/0f86d31426c69c1757dd6432d965597b)