### PR TITLE
サービス一覧ページに表示されるサービスのデータのフォーマットを調整

### DIFF
--- a/app/javascript/components/ServiceItem.css
+++ b/app/javascript/components/ServiceItem.css
@@ -1,0 +1,3 @@
+.list-item__memo {
+  white-space: pre-line;
+}

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { formatDate, formatPlan } from '../helpers/service';
+import { formatDate, formatPlan, formatPrice } from '../helpers/service';
 
 const ServiceItem = ({ service, onDelete }) => (
   <div className="list">
     <div className="list--display">
       <div className="list-item col-lg">{service.name}</div>
       <div className="list-item col-sm">{formatPlan(service.plan)}</div>
-      <div className="list-item col-sm">{service.price}</div>
+      <div className="list-item col-sm">{formatPrice(service.price)}</div>
       <div className="list-item__renewal">
         <span className="list-item__renewal-text">{formatDate(service.renewed_on)}</span>
       </div>

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Linkify from 'linkifyjs/react';
 import { formatDate, formatPlan, formatPrice } from '../helpers/service';
 
 const ServiceItem = ({ service, onDelete }) => (
@@ -16,7 +17,7 @@ const ServiceItem = ({ service, onDelete }) => (
       </div>
       <div className="list--expandable">
         <div className="list-item list-item__memo">
-          <p>{service.description}</p>
+          <Linkify tagName="p" options={{ target: '_blank' }}>{service.description}</Linkify>
         </div>
         <div className="list__actions">
           <div className="list__action">

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { formatDate } from '../helpers/service';
+import { formatDate, formatPlan } from '../helpers/service';
 
 const ServiceItem = ({ service, onDelete }) => (
   <div className="list">
     <div className="list--display">
       <div className="list-item col-lg">{service.name}</div>
-      <div className="list-item col-sm">{service.plan}</div>
+      <div className="list-item col-sm">{formatPlan(service.plan)}</div>
       <div className="list-item col-sm">{service.price}</div>
       <div className="list-item__renewal">
         <span className="list-item__renewal-text">{formatDate(service.renewed_on)}</span>

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Linkify from 'linkifyjs/react';
 import { formatDate, formatPlan, formatPrice } from '../helpers/service';
+import './ServiceItem.css';
 
 const ServiceItem = ({ service, onDelete }) => (
   <div className="list">
@@ -16,8 +17,8 @@ const ServiceItem = ({ service, onDelete }) => (
         <span className="list-item__remind-text">{formatDate(service.remind_on)}</span>
       </div>
       <div className="list--expandable">
-        <div className="list-item list-item__memo">
-          <Linkify tagName="p" options={{ target: '_blank' }}>{service.description}</Linkify>
+        <div className="list-item">
+          <Linkify className="list-item__memo" tagName="p" options={{ target: '_blank' }}>{service.description}</Linkify>
         </div>
         <div className="list__actions">
           <div className="list__action">

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { formatDate } from '../helpers/service';
 
 const ServiceItem = ({ service, onDelete }) => (
   <div className="list">
@@ -8,10 +9,10 @@ const ServiceItem = ({ service, onDelete }) => (
       <div className="list-item col-sm">{service.plan}</div>
       <div className="list-item col-sm">{service.price}</div>
       <div className="list-item__renewal">
-        <span className="list-item__renewal-text">{service.renewed_on}</span>
+        <span className="list-item__renewal-text">{formatDate(service.renewed_on)}</span>
       </div>
       <div className="list-item__remind">
-        <span className="list-item__remind-text">{service.remind_on}</span>
+        <span className="list-item__remind-text">{formatDate(service.remind_on)}</span>
       </div>
       <div className="list--expandable">
         <div className="list-item list-item__memo">

--- a/app/javascript/components/TotalPriceItem.js
+++ b/app/javascript/components/TotalPriceItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { formatPrice } from '../helpers/service';
 
 const TotalPriceItem = ({ amountPrice, color, children }) => (
   <div className={`card card--${color}`}>
@@ -8,7 +9,7 @@ const TotalPriceItem = ({ amountPrice, color, children }) => (
         {children}
       </div>
       <div className="card__amount">
-        {amountPrice}
+        {formatPrice(amountPrice)}
       </div>
     </div>
   </div>

--- a/app/javascript/helpers/service.js
+++ b/app/javascript/helpers/service.js
@@ -39,3 +39,5 @@ export const formatPlan = (plan) => {
       return null;
   }
 };
+
+export const formatPrice = (price) => `¥${price.toLocaleString()}`;

--- a/app/javascript/helpers/service.js
+++ b/app/javascript/helpers/service.js
@@ -28,3 +28,14 @@ export const formatDate = (date) => {
   }
   return `${year}年${month}月${day}日`;
 };
+
+export const formatPlan = (plan) => {
+  switch (plan) {
+    case 'monthly':
+      return '月額';
+    case 'yearly':
+      return '年額';
+    default:
+      return null;
+  }
+};

--- a/app/javascript/helpers/service.js
+++ b/app/javascript/helpers/service.js
@@ -14,3 +14,17 @@ export const calcMonthlyAverageAmount = (services) => {
   const monthlyAveragePrice = calcAnnualTotalAmount(services) / 12;
   return Math.floor(monthlyAveragePrice);
 };
+
+export const formatDate = (date) => {
+  if (date === null) return null;
+
+  const dateObj = new Date(date);
+  const today = new Date();
+  const year = dateObj.getFullYear();
+  const month = dateObj.getMonth() + 1;
+  const day = dateObj.getDate();
+  if (today.getFullYear() === year) {
+    return `${month}月${day}日`;
+  }
+  return `${year}年${month}月${day}日`;
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
+    "linkifyjs": "^2.1.9",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4627,6 +4627,11 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
+linkifyjs@^2.1.9:
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/linkifyjs/-/linkifyjs-2.1.9.tgz#af06e45a2866ff06c4766582590d098a4d584702"
+  integrity sha512-74ivurkK6WHvHFozVaGtQWV38FzBwSTGNmJolEgFp7QgR2bl6ArUWlvT4GcHKbPe1z3nWYi+VUdDZk16zDOVug==
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"


### PR DESCRIPTION
ref: #38 

## 概要

- 更新日や通知日がYYYY年MM月DD日(先頭の0は省略)と表示されるようにフォーマットを調整する関数を定義
- プランが月額/年額と表示されるようにした
- 料金表示のフォーマットの調整
    - 桁を3桁で区切る
    - 先頭に通貨記号を表示
        - 現在は日本円が入力される想定しかできていないので日本の通貨記号のみに対応している
- linkifyjsを導入し、メモ欄に含まれるURLはリンクとして生成されるようにした
- メモ欄の改行が反映されるようにスタイルを追加
    - 元々のPreBillではRailsの`simple_format`で整形していたが、現状のメモ欄には改行があったときにbrタグを生成したり、連続する改行があるときにpタグを生成させることと、CSSで改行を反映されるように調整することに違いがないのではないかと判断し、シンプルな方法であるCSSでスタイルを追加する方法で改行を反映させた。

## スクリーンショット

[![Image from Gyazo](https://i.gyazo.com/c6c7d0de9e7701abac630ddd6ba5f741.png)](https://gyazo.com/c6c7d0de9e7701abac630ddd6ba5f741)