### PR TITLE
サービス一覧ページのページヘッダ部分をコンポーネントに分割

### DIFF
--- a/app/assets/stylesheets/App.scss
+++ b/app/assets/stylesheets/App.scss
@@ -1,0 +1,7 @@
+//Page Header
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/app/javascript/components/LinkButton.js
+++ b/app/javascript/components/LinkButton.js
@@ -1,7 +1,13 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const LinkButton = ({ href, children }) => (
   <a href={href}>{children}</a>
 );
 
 export default LinkButton;
+
+LinkButton.propTypes = {
+  href: PropTypes.string.isRequired,
+  children: PropTypes.string.isRequired,
+};

--- a/app/javascript/components/LinkButton.js
+++ b/app/javascript/components/LinkButton.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const LinkButton = ({ href, children }) => (
+  <a href={href}>{children}</a>
+);
+
+export default LinkButton;

--- a/app/javascript/components/PageHeader.js
+++ b/app/javascript/components/PageHeader.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+const PageHeader = ({ children }) => (
+  <header className="page-header">
+    {children}
+  </header>
+);
+
+export default PageHeader;

--- a/app/javascript/components/PageHeader.js
+++ b/app/javascript/components/PageHeader.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const PageHeader = ({ children }) => (
   <header className="page-header">
@@ -7,3 +8,7 @@ const PageHeader = ({ children }) => (
 );
 
 export default PageHeader;
+
+PageHeader.propTypes = {
+  children: PropTypes.arrayOf(PropTypes.element).isRequired,
+};

--- a/app/javascript/components/PageHeaderTitle.js
+++ b/app/javascript/components/PageHeaderTitle.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const PageHeaderTitle = ({ children }) => (
+  <h2 className="page-header__title">{children}</h2>
+);
+
+export default PageHeaderTitle;
+
+PageHeaderTitle.propTypes = {
+  children: PropTypes.string.isRequired,
+};

--- a/app/javascript/components/UsingServices.js
+++ b/app/javascript/components/UsingServices.js
@@ -10,7 +10,7 @@ const UsingServices = ({ services, onDelete }) => (
   <>
     <PageHeader>
       <PageHeaderTitle>利用中のサービス</PageHeaderTitle>
-      <div className="page-body__actions">
+      <div>
         <LinkButton href="/services/new">新規登録</LinkButton>
       </div>
     </PageHeader>

--- a/app/javascript/components/UsingServices.js
+++ b/app/javascript/components/UsingServices.js
@@ -2,13 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ServiceList from './ServiceList';
 import ServiceItem from './ServiceItem';
+import PageHeader from './PageHeader';
+import PageHeaderTitle from './PageHeaderTitle';
+import LinkButton from './LinkButton';
 
 const UsingServices = ({ services, onDelete }) => (
   <div className="page-body">
-    <h3 className="page-body__header">利用中のサービス</h3>
-    <div className="page-body__actions">
-      <a href="/services/new">新規登録</a>
-    </div>
+    <PageHeader>
+      <PageHeaderTitle>利用中のサービス</PageHeaderTitle>
+      <div className="page-body__actions">
+        <LinkButton href="/services/new">新規登録</LinkButton>
+      </div>
+    </PageHeader>
     <div className="page-body__inner">
       <ServiceList>
         {services.map((service) => (

--- a/app/javascript/components/UsingServices.js
+++ b/app/javascript/components/UsingServices.js
@@ -7,21 +7,19 @@ import PageHeaderTitle from './PageHeaderTitle';
 import LinkButton from './LinkButton';
 
 const UsingServices = ({ services, onDelete }) => (
-  <div className="page-body">
+  <>
     <PageHeader>
       <PageHeaderTitle>利用中のサービス</PageHeaderTitle>
       <div className="page-body__actions">
         <LinkButton href="/services/new">新規登録</LinkButton>
       </div>
     </PageHeader>
-    <div className="page-body__inner">
-      <ServiceList>
-        {services.map((service) => (
-          <ServiceItem service={service} onDelete={onDelete} key={service.id} />
-        ))}
-      </ServiceList>
-    </div>
-  </div>
+    <ServiceList>
+      {services.map((service) => (
+        <ServiceItem service={service} onDelete={onDelete} key={service.id} />
+      ))}
+    </ServiceList>
+  </>
 );
 
 export default UsingServices;


### PR DESCRIPTION
ref: #23

## 概要

- サービス一覧ページのページヘッダ(利用中のサービス、新規登録ボタン)をコンポーネントに分割
    - PageHeaderコンポーネントを作成
    - PageHeaderTitleコンポーネントにページヘッダのタイトルを表示するようにした
        - サービス登録/編集ページなどで再利用できるようにコンポーネントに分割
        - 「利用中のサービス」と表示される部分とサービス登録/編集ページに表示されるヘッダのタイトルはスタイル(文字の大きさ)が異なるが、クラスを分けることで適用されるスタイルを使い分けられるようにする
            - 後半のデザインを進める際に着手予定
- 画面遷移するボタンのコンポーネントを作成
    - 遷移先と画面に表示される文字を受け取り、コンポーネント内で表示
    - スタイルの適用はこの後のボタンをコンポーネントに分けるissueで着手
- 不要だと考えたクラスを削除
    - 元の実装で上下の余白の調整としてのみを目的として利用していたクラスは他のクラスで調節が可能だと考え削除した