### PR TITLE
ベースとなるスタイルを定義

### DIFF
--- a/app/assets/stylesheets/App.scss
+++ b/app/assets/stylesheets/App.scss
@@ -3,6 +3,11 @@
 $blue: #1A0DAB;
 $deep_blue: #2E5173;
 $very_light_blue: #F9FAFE;
+$light-gray: #DDDDDD;
+
+// Dimensions
+
+$header-height: 3rem;
 
 // Base
 
@@ -30,6 +35,16 @@ a {
 
 img {
   max-width: 100%;
+}
+
+//Page
+
+.page {
+  border: 1px solid $light-gray;
+  background-color: white;
+  min-height: calc(100vh - #{$header-height});
+  padding: 2rem 1.875rem 0;
+  box-shadow: 0 1px 8px 0 rgba(0, 0, 0, 0.06);
 }
 
 //Page Header

--- a/app/assets/stylesheets/App.scss
+++ b/app/assets/stylesheets/App.scss
@@ -1,3 +1,31 @@
+// Color
+
+$blue: #1A0DAB;
+$deep_blue: #2E5173;
+$very_light_blue: #F9FAFE;
+
+// Base
+
+html {
+  font-size: 100%;
+}
+
+body {
+  font-family: "Yu Gothic Medium", "游ゴシック Medium", "游ゴシック体", "Hiragino Sans", "ヒラギノ角ゴ Pro W3", Sans-Serif;
+  line-height: 1.7;
+  background-color: $very_light_blue;
+  color: $deep_blue;
+}
+
+a {
+  text-decoration: none;
+  color: $blue;
+}
+
+img {
+  max-width: 100%;
+}
+
 //Page Header
 
 .page-header {

--- a/app/assets/stylesheets/App.scss
+++ b/app/assets/stylesheets/App.scss
@@ -17,6 +17,12 @@ body {
   color: $deep_blue;
 }
 
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 4%;
+}
+
 a {
   text-decoration: none;
   color: $blue;

--- a/app/javascript/packs/services/edit.js
+++ b/app/javascript/packs/services/edit.js
@@ -2,11 +2,19 @@ import React from 'react';
 import { render } from 'react-dom';
 import EditService from '../../components/EditService';
 
+const Edit = ({ serviceId }) => (
+  <div className="container">
+    <main className="page">
+      <EditService serviceId={serviceId} />
+    </main>
+  </div>
+);
+
 document.addEventListener('DOMContentLoaded', () => {
   const el = document.querySelector('#root');
   const { serviceId } = el.dataset;
   render(
-    <EditService serviceId={serviceId} />,
+    <Edit serviceId={serviceId} />,
     el,
   );
 });

--- a/app/javascript/packs/services/edit.js
+++ b/app/javascript/packs/services/edit.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { render } from 'react-dom';
 import EditService from '../../components/EditService';
 
@@ -18,3 +19,11 @@ document.addEventListener('DOMContentLoaded', () => {
     el,
   );
 });
+
+Edit.propTypes = {
+  serviceId: PropTypes.string,
+};
+
+Edit.defaultProps = {
+  serviceId: '',
+};

--- a/app/javascript/packs/services/index.js
+++ b/app/javascript/packs/services/index.js
@@ -65,9 +65,11 @@ class Index extends React.Component {
     return (
       <div className="container">
         <Flash services={services} />
-        <TotalPriceList services={services} />
-        <UsingServices onDelete={this.deleteService} services={services} />
-      </>
+        <main className="page">
+          <TotalPriceList services={services} />
+          <UsingServices onDelete={this.deleteService} services={services} />
+        </main>
+      </div>
     );
   }
 }

--- a/app/javascript/packs/services/index.js
+++ b/app/javascript/packs/services/index.js
@@ -63,7 +63,7 @@ class Index extends React.Component {
     }
 
     return (
-      <>
+      <div className="container">
         <Flash services={services} />
         <TotalPriceList services={services} />
         <UsingServices onDelete={this.deleteService} services={services} />

--- a/app/javascript/packs/services/new.js
+++ b/app/javascript/packs/services/new.js
@@ -2,9 +2,17 @@ import React from 'react';
 import { render } from 'react-dom';
 import NewService from '../../components/NewService';
 
+const New = () => (
+  <div className="container">
+    <main className="page">
+      <NewService />
+    </main>
+  </div>
+);
+
 document.addEventListener('DOMContentLoaded', () => {
   render(
-    <NewService />,
+    <New />,
     document.querySelector('#root'),
   );
 });

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,2 @@
 <%= javascript_pack_tag 'services/index' %>
 <div id="root"></div>
-<h1>Home#index</h1>
-<p>Find me in app/views/home/index.html.erb</p>


### PR DESCRIPTION
## 概要

- ページレイアウトのスタイルを定義
    - 元のPreBillで定義されているスタイルを適用
- NewコンポーネントとEditコンポーネントを定義
    - ヘッダーを除いたページ全体のレイアウトを整えるためにコンポーネントを作成
    - このコンポーネントに今後作成するヘッダーを含める予定
- views/home/index.html.erb内の不要な文言を削除

## スクリーンショット

トップページ
[![Image from Gyazo](https://i.gyazo.com/17da77b0095c4c244baf10a8e630f146.png)](https://gyazo.com/17da77b0095c4c244baf10a8e630f146)

新規登録ページ
[![Image from Gyazo](https://i.gyazo.com/79fa3a93e5f4013cab6c10c94f9f0258.png)](https://gyazo.com/79fa3a93e5f4013cab6c10c94f9f0258)