### PR TITLE
ボタンコンポーネントを追加

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -55,6 +55,10 @@ img {
   align-items: center;
 }
 
+.page-header__action {
+  min-width: 8rem;
+}
+
 // Button
 
 .btn {

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -55,6 +55,65 @@ img {
   align-items: center;
 }
 
+// Button
+
+.btn {
+  color: white;
+  font-weight: 600;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 4px;
+  user-select: none;
+  transition: all ease-out .2s;
+  letter-spacing: 2px;
+  text-decoration: none;
+}
+
+.btn--sm {
+  height: 1.5rem;
+  padding: 0 .5rem;
+  font-size: .8rem;
+}
+
+.btn--md {
+  height: 2.3rem;
+  padding: 0 .5rem;
+  font-size: .8rem;
+}
+
+.btn--primary {
+  border: 1px solid #2274E5;
+  background-color: #2274E5;
+  &:hover {
+    background-color: #1267E6;
+    border-color: #2274E5;
+  }
+}
+
+.btn--secondary {
+  color: #444444;
+  background-color: white;
+  border: 1px solid #d8d8d8;
+  letter-spacing: normal;
+  &:hover {
+    border-color: rgba(0, 0, 0, 0.4);
+  }
+}
+
+.btn--danger {
+  border: 1px solid #FF5555;
+  background-color: #F0514F;
+  &:hover {
+    background-color: #e44e4e;
+    border: 1px solid #e44e4e;
+  }
+}
+
+.btn--block {
+  width: 100%;
+}
+
 // list-item
 
 .list-item__memo {

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -59,6 +59,16 @@ img {
   min-width: 8rem;
 }
 
+// list
+
+.list__actions {
+  display: flex;
+}
+
+.list__action:not(:last-child) {
+  padding-right: 1rem;
+}
+
 // Button
 
 .btn {

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -128,6 +128,25 @@ img {
   width: 100%;
 }
 
+// form
+
+.form-actions__items {
+  list-style: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 1.5rem 0;
+}
+
+.form-actions__item {
+  padding: 0 .5rem;
+  min-width: 12rem;
+}
+
+.form-actions__item--cancel {
+  padding: 0 .5rem;
+}
+
 // list-item
 
 .list-item__memo {

--- a/app/javascript/components/Button.js
+++ b/app/javascript/components/Button.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Button = ({
+  onClick, children, color, size, block,
+}) => (
+  <button type="button" onClick={() => onClick()} className={`btn ${color} ${size} ${block}`}>{children}</button>
+);
+
+export default Button;
+
+Button.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  children: PropTypes.string.isRequired,
+  color: PropTypes.string,
+  size: PropTypes.string,
+  block: PropTypes.string,
+};
+
+Button.defaultProps = {
+  color: '',
+  size: '',
+  block: '',
+};

--- a/app/javascript/components/Button.js
+++ b/app/javascript/components/Button.js
@@ -3,22 +3,23 @@ import PropTypes from 'prop-types';
 
 const Button = ({
   onClick, children, color, size, block,
-}) => (
-  <button type="button" onClick={() => onClick()} className={`btn ${color} ${size} ${block}`}>{children}</button>
-);
+}) => {
+  const btnBlock = block === '' ? '' : `btn--${block}`;
+  return (
+    <button type="button" onClick={() => onClick()} className={`btn btn--${color} btn--${size} ${btnBlock}`}>{children}</button>
+  );
+};
 
 export default Button;
 
 Button.propTypes = {
   onClick: PropTypes.func.isRequired,
   children: PropTypes.string.isRequired,
-  color: PropTypes.string,
-  size: PropTypes.string,
+  color: PropTypes.string.isRequired,
+  size: PropTypes.string.isRequired,
   block: PropTypes.string,
 };
 
 Button.defaultProps = {
-  color: '',
-  size: '',
   block: '',
 };

--- a/app/javascript/components/Button.js
+++ b/app/javascript/components/Button.js
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Button = ({
-  onClick, children, color, size, block,
+  onClick, children, color, size, isBlock,
 }) => {
-  const btnBlock = block === '' ? '' : `btn--${block}`;
+  const block = isBlock ? 'btn--block' : '';
   return (
-    <button type="button" onClick={() => onClick()} className={`btn btn--${color} btn--${size} ${btnBlock}`}>{children}</button>
+    <button type="button" onClick={() => onClick()} className={`btn btn--${color} btn--${size} ${block}`}>{children}</button>
   );
 };
 
@@ -17,9 +17,9 @@ Button.propTypes = {
   children: PropTypes.string.isRequired,
   color: PropTypes.string.isRequired,
   size: PropTypes.string.isRequired,
-  block: PropTypes.string,
+  isBlock: PropTypes.bool,
 };
 
 Button.defaultProps = {
-  block: '',
+  isBlock: false,
 };

--- a/app/javascript/components/LinkButton.js
+++ b/app/javascript/components/LinkButton.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const LinkButton = ({ href, children }) => (
-  <a href={href}>{children}</a>
+const LinkButton = ({
+  href, children, color, size,
+}) => (
+  <a href={href} className={`btn ${color} ${size}`}>{children}</a>
 );
 
 export default LinkButton;
@@ -10,4 +12,11 @@ export default LinkButton;
 LinkButton.propTypes = {
   href: PropTypes.string.isRequired,
   children: PropTypes.string.isRequired,
+  color: PropTypes.string,
+  size: PropTypes.string,
+};
+
+LinkButton.defaultProps = {
+  color: '',
+  size: '',
 };

--- a/app/javascript/components/LinkButton.js
+++ b/app/javascript/components/LinkButton.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 const LinkButton = ({
   href, children, color, size,
 }) => (
-  <a href={href} className={`btn ${color} ${size}`}>{children}</a>
+  <a href={href} className={`btn btn--${color} btn--${size}`}>{children}</a>
 );
 
 export default LinkButton;
@@ -12,11 +12,6 @@ export default LinkButton;
 LinkButton.propTypes = {
   href: PropTypes.string.isRequired,
   children: PropTypes.string.isRequired,
-  color: PropTypes.string,
-  size: PropTypes.string,
-};
-
-LinkButton.defaultProps = {
-  color: '',
-  size: '',
+  color: PropTypes.string.isRequired,
+  size: PropTypes.string.isRequired,
 };

--- a/app/javascript/components/ServiceForm.js
+++ b/app/javascript/components/ServiceForm.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ValidationErrors from './ValidationErrors';
 import LinkButton from './LinkButton';
+import Button from './Button';
 
 class ServiceForm extends React.Component {
   constructor(props) {
@@ -46,7 +47,7 @@ class ServiceForm extends React.Component {
 
         <ValidationErrors errorMessages={errorMessages} />
 
-        <form onSubmit={this.handleSubmit}>
+        <form onSubmit={this.handleSubmit} id="service-form">
           <div className="form-items">
             <div className="form-item">
               <label htmlFor="service_name">
@@ -133,7 +134,14 @@ class ServiceForm extends React.Component {
           </div>
           <ul className="form-actions__items">
             <li className="form-actions__item">
-              <input type="submit" value="登録" name="commit" />
+              <Button
+                onClick={() => { document.getElementById('service-form').dispatchEvent(new Event('submit')); }}
+                color="btn--primary"
+                size="btn--md"
+                block="btn--block"
+              >
+                登録
+              </Button>
             </li>
             <li className="form-actions__item--cancel">
               <LinkButton href="/" color="btn--secondary" size="btn--md">キャンセル</LinkButton>

--- a/app/javascript/components/ServiceForm.js
+++ b/app/javascript/components/ServiceForm.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ValidationErrors from './ValidationErrors';
+import LinkButton from './LinkButton';
 
 class ServiceForm extends React.Component {
   constructor(props) {
@@ -135,7 +136,7 @@ class ServiceForm extends React.Component {
               <input type="submit" value="登録" name="commit" />
             </li>
             <li className="form-actions__item--cancel">
-              <a href="/">キャンセル</a>
+              <LinkButton href="/" color="btn--secondary" size="btn--md">キャンセル</LinkButton>
             </li>
           </ul>
         </form>

--- a/app/javascript/components/ServiceForm.js
+++ b/app/javascript/components/ServiceForm.js
@@ -144,7 +144,7 @@ class ServiceForm extends React.Component {
               </Button>
             </li>
             <li className="form-actions__item--cancel">
-              <LinkButton href="/" color="btn--secondary" size="btn--md">キャンセル</LinkButton>
+              <LinkButton href="/" color="secondary" size="md">キャンセル</LinkButton>
             </li>
           </ul>
         </form>

--- a/app/javascript/components/ServiceForm.js
+++ b/app/javascript/components/ServiceForm.js
@@ -136,9 +136,9 @@ class ServiceForm extends React.Component {
             <li className="form-actions__item">
               <Button
                 onClick={() => { document.getElementById('service-form').dispatchEvent(new Event('submit')); }}
-                color="btn--primary"
-                size="btn--md"
-                block="btn--block"
+                color="primary"
+                size="md"
+                block="block"
               >
                 登録
               </Button>

--- a/app/javascript/components/ServiceForm.js
+++ b/app/javascript/components/ServiceForm.js
@@ -138,7 +138,7 @@ class ServiceForm extends React.Component {
                 onClick={() => { document.getElementById('service-form').dispatchEvent(new Event('submit')); }}
                 color="primary"
                 size="md"
-                block="block"
+                isBlock
               >
                 登録
               </Button>

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -28,8 +28,8 @@ const ServiceItem = ({ service, onDelete }) => (
           <div className="list__action">
             <Button
               onClick={() => onDelete(service.id)}
-              color="btn--danger"
-              size="btn--sm"
+              color="danger"
+              size="sm"
             >
               削除
             </Button>

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Linkify from 'linkifyjs/react';
 import { formatDate, formatPlan, formatPrice } from '../helpers/service';
+import LinkButton from './LinkButton';
 
 const ServiceItem = ({ service, onDelete }) => (
   <div className="list">
@@ -21,7 +22,7 @@ const ServiceItem = ({ service, onDelete }) => (
         </div>
         <div className="list__actions">
           <div className="list__action">
-            <a href={`services/${service.id}/edit`} className="btn--full btn--sm btn--secondary">修正</a>
+            <LinkButton href={`services/${service.id}/edit`} color="btn--secondary" size="btn--sm">修正</LinkButton>
           </div>
           <div className="list__action">
             <button type="button" onClick={() => onDelete(service.id)}>削除</button>

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -23,7 +23,7 @@ const ServiceItem = ({ service, onDelete }) => (
         </div>
         <div className="list__actions">
           <div className="list__action">
-            <LinkButton href={`services/${service.id}/edit`} color="btn--secondary" size="btn--sm">修正</LinkButton>
+            <LinkButton href={`services/${service.id}/edit`} color="secondary" size="sm">修正</LinkButton>
           </div>
           <div className="list__action">
             <Button

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Linkify from 'linkifyjs/react';
 import { formatDate, formatPlan, formatPrice } from '../helpers/service';
 import LinkButton from './LinkButton';
+import Button from './Button';
 
 const ServiceItem = ({ service, onDelete }) => (
   <div className="list">
@@ -25,7 +26,13 @@ const ServiceItem = ({ service, onDelete }) => (
             <LinkButton href={`services/${service.id}/edit`} color="btn--secondary" size="btn--sm">修正</LinkButton>
           </div>
           <div className="list__action">
-            <button type="button" onClick={() => onDelete(service.id)}>削除</button>
+            <Button
+              onClick={() => onDelete(service.id)}
+              color="btn--danger"
+              size="btn--sm"
+            >
+              削除
+            </Button>
           </div>
         </div>
       </div>

--- a/app/javascript/components/UsingServices.js
+++ b/app/javascript/components/UsingServices.js
@@ -10,8 +10,8 @@ const UsingServices = ({ services, onDelete }) => (
   <>
     <PageHeader>
       <PageHeaderTitle>利用中のサービス</PageHeaderTitle>
-      <div>
-        <LinkButton href="/services/new">新規登録</LinkButton>
+      <div className="page-header__action">
+        <LinkButton href="/services/new" color="btn--primary" size="btn--md">新規登録</LinkButton>
       </div>
     </PageHeader>
     <ServiceList>

--- a/app/javascript/components/UsingServices.js
+++ b/app/javascript/components/UsingServices.js
@@ -11,7 +11,7 @@ const UsingServices = ({ services, onDelete }) => (
     <PageHeader>
       <PageHeaderTitle>利用中のサービス</PageHeaderTitle>
       <div className="page-header__action">
-        <LinkButton href="/services/new" color="btn--primary" size="btn--md">新規登録</LinkButton>
+        <LinkButton href="/services/new" color="primary" size="md">新規登録</LinkButton>
       </div>
     </PageHeader>
     <ServiceList>


### PR DESCRIPTION
ref: #23 

## 概要

- ButtonコンポーネントとLinkButtonコンポーネントを作成
    - 画面遷移するボタンとアクションを実行するボタンでコンポーネントを分割した
    - Buttonコンポーネントはイベントハンドラを受け取り、コンポーネント内で実行するようにした
    - LinkButtonコンポーネントは、遷移先を受け取り、ボタンを押下することで指定された先に遷移するようにした
- これまで作成したページ内で表示されているボタンをコンポーネントを利用するように修正
- スタイルを追加
    - ボタンの色、サイズ等を調整するスタイルを追加
        - サービス登録、編集フォームのボタンについてスタイルを追加
        - サービス一覧ページの修正/削除ボタンのスタイルを追加

## スクリーンショット

サービス一覧ページ

[![Image from Gyazo](https://i.gyazo.com/793fbeb24ab345af357d5b263a68743a.png)](https://gyazo.com/793fbeb24ab345af357d5b263a68743a)

サービス登録、編集フォーム

[![Image from Gyazo](https://i.gyazo.com/0da99f86ce6fae953254bc162958851f.png)](https://gyazo.com/0da99f86ce6fae953254bc162958851f)
