### PR TITLE
サービス一覧に表示されている部分をコンポーネントに分割

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -231,12 +231,14 @@ img {
 }
 
 .list-item__element {
-  flex: 1 1 15%;
   font-size: .9rem;
   &.col-lg {
     flex: 1 1 25%;
   }
   &.col-sm {
     flex: 1 1 10%;
+  }
+  &.col-md {
+    flex: 1 1 15%;
   }
 }

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -147,6 +147,25 @@ img {
   padding: 0 .5rem;
 }
 
+// list label
+
+.list__labels {
+  display: flex;
+  padding: 0 1.5rem;
+}
+
+.list__label {
+  flex: 1 1 15%;
+  font-size: .8rem;
+  color: #666666;
+  &.col-lg {
+    flex: 1 1 25%;
+  }
+  &.col-sm {
+    flex: 1 1 10%;
+  }
+}
+
 // list-item
 
 .list-item__memo {

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -145,7 +145,6 @@ img {
 }
 
 .list__label {
-  flex: 1 1 15%;
   font-size: .8rem;
   color: #666666;
   &.col-lg {
@@ -153,6 +152,9 @@ img {
   }
   &.col-sm {
     flex: 1 1 10%;
+  }
+  &.col-md {
+    flex: 1 1 15%;
   }
 }
 

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -59,16 +59,6 @@ img {
   min-width: 8rem;
 }
 
-// list
-
-.list__actions {
-  display: flex;
-}
-
-.list__action:not(:last-child) {
-  padding-right: 1rem;
-}
-
 // Button
 
 .btn {
@@ -166,8 +156,85 @@ img {
   }
 }
 
-// list-item
+// list item
 
-.list-item__memo {
-  white-space: pre-line;
+.list-item {
+  border: 1px solid #ddd;
+  background-color: white;
+  border-radius: 5px;
+  margin-bottom: 1rem;
+  padding: .85rem 1.5rem;
+  &__title {
+    font-size: .95rem;
+    font-weight: 600;
+  }
+  &__memo {
+    padding: 1rem 5px;
+    font-size: .895rem;
+    white-space: pre-line;
+  }
+}
+
+.list-item--display {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.list-item__expand {
+  display: inline-block;
+  width: 24px;
+  height: 24px;
+  background-color: #DDE5F0;
+  border-radius: 50%;
+  transition: all ease .2s;
+  cursor: pointer;
+  text-align: center;
+  position: relative;
+  &::before {
+    display: inline-block;
+    content: "⌵";
+    position: absolute;
+    top: -3px;
+    right: 0;
+    left: 0;
+    z-index: 1;
+  }
+  &:hover {
+    background-color: #2274E5;
+    color: white;
+  }
+  &.is-checked {
+    background-color: #2274E5;
+    color: white;
+    &::before {
+      transform: rotateX(180deg);
+      top: 2px;
+    }
+  }
+}
+
+.list-item__expand:focus {
+  outline: 0;
+}
+
+.list-item__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.list-item__action:not(:last-child) {
+  padding-right: 1rem;
+}
+
+.list-item__element {
+  flex: 1 1 15%;
+  font-size: .9rem;
+  &.col-lg {
+    flex: 1 1 25%;
+  }
+  &.col-sm {
+    flex: 1 1 10%;
+  }
 }

--- a/app/javascript/components/ExpandButton.js
+++ b/app/javascript/components/ExpandButton.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ExpandButton = ({ onClick, isExpand }) => {
+  const className = isExpand ? 'list-item__expand is-checked' : 'list-item__expand';
+  return (
+
+    <button type="button" aria-label="expand" className={className} onClick={onClick} />
+  );
+};
+
+export default ExpandButton;
+
+ExpandButton.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  isExpand: PropTypes.bool.isRequired,
+};

--- a/app/javascript/components/ListDisplayedItem.js
+++ b/app/javascript/components/ListDisplayedItem.js
@@ -6,11 +6,11 @@ import ExpandButton from './ExpandButton';
 
 const ListDisplayedItem = ({ service, onClick, isExpand }) => (
   <div className="list-item--display">
-    <ServiceItemElement size="col-lg">
+    <ServiceItemElement size="lg">
       <span className="list-item__title">{service.name}</span>
     </ServiceItemElement>
-    <ServiceItemElement size="col-sm">{formatPlan(service.plan)}</ServiceItemElement>
-    <ServiceItemElement size="col-sm">{formatPrice(service.price)}</ServiceItemElement>
+    <ServiceItemElement size="sm">{formatPlan(service.plan)}</ServiceItemElement>
+    <ServiceItemElement size="sm">{formatPrice(service.price)}</ServiceItemElement>
     <ServiceItemElement>{formatDate(service.renewed_on)}</ServiceItemElement>
     <ServiceItemElement>{formatDate(service.remind_on)}</ServiceItemElement>
     <ExpandButton onClick={onClick} isExpand={isExpand} />

--- a/app/javascript/components/ListDisplayedItem.js
+++ b/app/javascript/components/ListDisplayedItem.js
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ServiceItemElement from './ServiceItemElement';
 import { formatDate, formatPlan, formatPrice } from '../helpers/service';
+import ExpandButton from './ExpandButton';
 
-const ListDisplayedItem = ({ service }) => (
+const ListDisplayedItem = ({ service, onClick, isExpand }) => (
   <div className="list-item--display">
     <ServiceItemElement size="col-lg">
       <span className="list-item__title">{service.name}</span>
@@ -12,6 +13,7 @@ const ListDisplayedItem = ({ service }) => (
     <ServiceItemElement size="col-sm">{formatPrice(service.price)}</ServiceItemElement>
     <ServiceItemElement>{formatDate(service.renewed_on)}</ServiceItemElement>
     <ServiceItemElement>{formatDate(service.remind_on)}</ServiceItemElement>
+    <ExpandButton onClick={onClick} isExpand={isExpand} />
   </div>
 );
 
@@ -26,6 +28,8 @@ ListDisplayedItem.propTypes = {
     renewed_on: PropTypes.string,
     remind_on: PropTypes.string,
   }),
+  onClick: PropTypes.func.isRequired,
+  isExpand: PropTypes.bool.isRequired,
 };
 
 ListDisplayedItem.defaultProps = {

--- a/app/javascript/components/ListDisplayedItem.js
+++ b/app/javascript/components/ListDisplayedItem.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ServiceItemElement from './ServiceItemElement';
+import { formatDate, formatPlan, formatPrice } from '../helpers/service';
+
+const ListDisplayedItem = ({ service }) => (
+  <div className="list-item--display">
+    <ServiceItemElement size="col-lg">
+      <span className="list-item__title">{service.name}</span>
+    </ServiceItemElement>
+    <ServiceItemElement size="col-sm">{formatPlan(service.plan)}</ServiceItemElement>
+    <ServiceItemElement size="col-sm">{formatPrice(service.price)}</ServiceItemElement>
+    <ServiceItemElement>{formatDate(service.renewed_on)}</ServiceItemElement>
+    <ServiceItemElement>{formatDate(service.remind_on)}</ServiceItemElement>
+  </div>
+);
+
+export default ListDisplayedItem;
+
+ListDisplayedItem.propTypes = {
+  service: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+    plan: PropTypes.string,
+    price: PropTypes.number,
+    renewed_on: PropTypes.string,
+    remind_on: PropTypes.string,
+  }),
+};
+
+ListDisplayedItem.defaultProps = {
+  service: undefined,
+};

--- a/app/javascript/components/ListExpandableItem.js
+++ b/app/javascript/components/ListExpandableItem.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Linkify from 'linkifyjs/react';
+import LinkButton from './LinkButton';
+import Button from './Button';
+
+const ListExpandableItem = ({ service, onDelete }) => (
+  <div className="list-item--expandable">
+    <Linkify className="list-item__memo" tagName="p" options={{ target: '_blank' }}>{service.description}</Linkify>
+    <div className="list-item__actions">
+      <div className="list-item__action">
+        <LinkButton href={`services/${service.id}/edit`} color="btn--secondary" size="btn--sm">修正</LinkButton>
+      </div>
+      <div className="list-item__action">
+        <Button
+          onClick={() => onDelete(service.id)}
+          color="btn--danger"
+          size="btn--sm"
+        >
+          削除
+        </Button>
+      </div>
+    </div>
+  </div>
+);
+
+export default ListExpandableItem;
+
+ListExpandableItem.propTypes = {
+  service: PropTypes.shape({
+    id: PropTypes.number,
+    description: PropTypes.string,
+  }),
+  onDelete: PropTypes.func.isRequired,
+};
+
+ListExpandableItem.defaultProps = {
+  service: undefined,
+};

--- a/app/javascript/components/ListExpandableItem.js
+++ b/app/javascript/components/ListExpandableItem.js
@@ -4,25 +4,31 @@ import Linkify from 'linkifyjs/react';
 import LinkButton from './LinkButton';
 import Button from './Button';
 
-const ListExpandableItem = ({ service, onDelete }) => (
-  <div className="list-item--expandable">
-    <Linkify className="list-item__memo" tagName="p" options={{ target: '_blank' }}>{service.description}</Linkify>
-    <div className="list-item__actions">
-      <div className="list-item__action">
-        <LinkButton href={`services/${service.id}/edit`} color="btn--secondary" size="btn--sm">修正</LinkButton>
-      </div>
-      <div className="list-item__action">
-        <Button
-          onClick={() => onDelete(service.id)}
-          color="btn--danger"
-          size="btn--sm"
-        >
-          削除
-        </Button>
+const ListExpandableItem = ({ service, onDelete, isExpand }) => {
+  if (!isExpand) {
+    return null;
+  }
+
+  return (
+    <div className="list-item--expandable">
+      <Linkify className="list-item__memo" tagName="p" options={{ target: '_blank' }}>{service.description}</Linkify>
+      <div className="list-item__actions">
+        <div className="list-item__action">
+          <LinkButton href={`services/${service.id}/edit`} color="secondary" size="sm">修正</LinkButton>
+        </div>
+        <div className="list-item__action">
+          <Button
+            onClick={() => onDelete(service.id)}
+            color="danger"
+            size="sm"
+          >
+            削除
+          </Button>
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default ListExpandableItem;
 
@@ -32,6 +38,7 @@ ListExpandableItem.propTypes = {
     description: PropTypes.string,
   }),
   onDelete: PropTypes.func.isRequired,
+  isExpand: PropTypes.bool.isRequired,
 };
 
 ListExpandableItem.defaultProps = {

--- a/app/javascript/components/ListLabelItem.js
+++ b/app/javascript/components/ListLabelItem.js
@@ -13,5 +13,5 @@ ListLabelItem.propTypes = {
 };
 
 ListLabelItem.defaultProps = {
-  colSize: '',
+  colSize: 'md',
 };

--- a/app/javascript/components/ListLabelItem.js
+++ b/app/javascript/components/ListLabelItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ListLabelItem = ({ colSize, children }) => (
-  <div className={`list__label ${colSize}`}>{children}</div>
+  <div className={`list__label col-${colSize}`}>{children}</div>
 );
 
 export default ListLabelItem;

--- a/app/javascript/components/ListLabelItem.js
+++ b/app/javascript/components/ListLabelItem.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ListLabelItem = ({ colSize, children }) => (
+  <div className={`list__label ${colSize}`}>{children}</div>
+);
+
+export default ListLabelItem;
+
+ListLabelItem.propTypes = {
+  colSize: PropTypes.string,
+  children: PropTypes.string.isRequired,
+};
+
+ListLabelItem.defaultProps = {
+  colSize: '',
+};

--- a/app/javascript/components/ListLabels.js
+++ b/app/javascript/components/ListLabels.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import ListLabelItem from './ListLabelItem';
+
+const ListLabels = () => (
+  <div className="list__labels">
+    <ListLabelItem colSize="col-lg">サービス名</ListLabelItem>
+    <ListLabelItem colSize="col-sm">プラン</ListLabelItem>
+    <ListLabelItem colSize="col-sm">料金</ListLabelItem>
+    <ListLabelItem>更新日</ListLabelItem>
+    <ListLabelItem>通知日</ListLabelItem>
+  </div>
+);
+
+export default ListLabels;

--- a/app/javascript/components/ListLabels.js
+++ b/app/javascript/components/ListLabels.js
@@ -3,9 +3,9 @@ import ListLabelItem from './ListLabelItem';
 
 const ListLabels = () => (
   <div className="list__labels">
-    <ListLabelItem colSize="col-lg">サービス名</ListLabelItem>
-    <ListLabelItem colSize="col-sm">プラン</ListLabelItem>
-    <ListLabelItem colSize="col-sm">料金</ListLabelItem>
+    <ListLabelItem colSize="lg">サービス名</ListLabelItem>
+    <ListLabelItem colSize="sm">プラン</ListLabelItem>
+    <ListLabelItem colSize="sm">料金</ListLabelItem>
     <ListLabelItem>更新日</ListLabelItem>
     <ListLabelItem>通知日</ListLabelItem>
   </div>

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -4,36 +4,35 @@ import Linkify from 'linkifyjs/react';
 import { formatDate, formatPlan, formatPrice } from '../helpers/service';
 import LinkButton from './LinkButton';
 import Button from './Button';
+import ServiceItemElement from './ServiceItemElement';
 
 const ServiceItem = ({ service, onDelete }) => (
   <div className="list">
     <div className="list--display">
-      <div className="list-item col-lg">{service.name}</div>
-      <div className="list-item col-sm">{formatPlan(service.plan)}</div>
-      <div className="list-item col-sm">{formatPrice(service.price)}</div>
-      <div className="list-item__renewal">
-        <span className="list-item__renewal-text">{formatDate(service.renewed_on)}</span>
+      <ServiceItemElement size="col-lg">
+        <span className="list-item__title">{service.name}</span>
+      </ServiceItemElement>
+      <ServiceItemElement size="col-sm">{formatPlan(service.plan)}</ServiceItemElement>
+      <ServiceItemElement size="col-sm">{formatPrice(service.price)}</ServiceItemElement>
+      <ServiceItemElement>{formatDate(service.renewed_on)}</ServiceItemElement>
+      <ServiceItemElement>{formatDate(service.remind_on)}</ServiceItemElement>
+    </div>
+    <div className="list--expandable">
+      <div className="list-item">
+        <Linkify className="list-item__memo" tagName="p" options={{ target: '_blank' }}>{service.description}</Linkify>
       </div>
-      <div className="list-item__remind">
-        <span className="list-item__remind-text">{formatDate(service.remind_on)}</span>
-      </div>
-      <div className="list--expandable">
-        <div className="list-item">
-          <Linkify className="list-item__memo" tagName="p" options={{ target: '_blank' }}>{service.description}</Linkify>
+      <div className="list__actions">
+        <div className="list__action">
+          <LinkButton href={`services/${service.id}/edit`} color="secondary" size="sm">修正</LinkButton>
         </div>
-        <div className="list__actions">
-          <div className="list__action">
-            <LinkButton href={`services/${service.id}/edit`} color="secondary" size="sm">修正</LinkButton>
-          </div>
-          <div className="list__action">
-            <Button
-              onClick={() => onDelete(service.id)}
-              color="danger"
-              size="sm"
-            >
-              削除
-            </Button>
-          </div>
+        <div className="list__action">
+          <Button
+            onClick={() => onDelete(service.id)}
+            color="danger"
+            size="sm"
+          >
+            削除
+          </Button>
         </div>
       </div>
     </div>

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -3,12 +3,34 @@ import PropTypes from 'prop-types';
 import ListDisplayedItem from './ListDisplayedItem';
 import ListExpandableItem from './ListExpandableItem';
 
-const ServiceItem = ({ service, onDelete }) => (
-  <div className="list-item">
-    <ListDisplayedItem service={service} />
-    <ListExpandableItem service={service} onDelete={onDelete} />
-  </div>
-);
+class ServiceItem extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isExpand: false,
+    };
+
+    this.handleExpand = this.handleExpand.bind(this);
+  }
+
+  handleExpand() {
+    this.setState((prevState) => ({
+      isExpand: !prevState.isExpand,
+    }));
+  }
+
+  render() {
+    const { service, onDelete } = this.props;
+    const { isExpand } = this.state;
+
+    return (
+      <div className="list-item">
+        <ListDisplayedItem service={service} onClick={this.handleExpand} isExpand={isExpand} />
+        <ListExpandableItem service={service} onDelete={onDelete} isExpand={isExpand} />
+      </div>
+    );
+  }
+}
 
 export default ServiceItem;
 

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -1,32 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Linkify from 'linkifyjs/react';
-import LinkButton from './LinkButton';
-import Button from './Button';
 import ListDisplayedItem from './ListDisplayedItem';
+import ListExpandableItem from './ListExpandableItem';
 
 const ServiceItem = ({ service, onDelete }) => (
   <div className="list-item">
     <ListDisplayedItem service={service} />
-    <div className="list--expandable">
-      <div className="list-item">
-        <Linkify className="list-item__memo" tagName="p" options={{ target: '_blank' }}>{service.description}</Linkify>
-      </div>
-      <div className="list__actions">
-        <div className="list__action">
-          <LinkButton href={`services/${service.id}/edit`} color="secondary" size="sm">修正</LinkButton>
-        </div>
-        <div className="list__action">
-          <Button
-            onClick={() => onDelete(service.id)}
-            color="danger"
-            size="sm"
-          >
-            削除
-          </Button>
-        </div>
-      </div>
-    </div>
+    <ListExpandableItem service={service} onDelete={onDelete} />
   </div>
 );
 

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -1,22 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Linkify from 'linkifyjs/react';
-import { formatDate, formatPlan, formatPrice } from '../helpers/service';
 import LinkButton from './LinkButton';
 import Button from './Button';
-import ServiceItemElement from './ServiceItemElement';
+import ListDisplayedItem from './ListDisplayedItem';
 
 const ServiceItem = ({ service, onDelete }) => (
-  <div className="list">
-    <div className="list--display">
-      <ServiceItemElement size="col-lg">
-        <span className="list-item__title">{service.name}</span>
-      </ServiceItemElement>
-      <ServiceItemElement size="col-sm">{formatPlan(service.plan)}</ServiceItemElement>
-      <ServiceItemElement size="col-sm">{formatPrice(service.price)}</ServiceItemElement>
-      <ServiceItemElement>{formatDate(service.renewed_on)}</ServiceItemElement>
-      <ServiceItemElement>{formatDate(service.remind_on)}</ServiceItemElement>
-    </div>
+  <div className="list-item">
+    <ListDisplayedItem service={service} />
     <div className="list--expandable">
       <div className="list-item">
         <Linkify className="list-item__memo" tagName="p" options={{ target: '_blank' }}>{service.description}</Linkify>

--- a/app/javascript/components/ServiceItemElement.js
+++ b/app/javascript/components/ServiceItemElement.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const ServiceItemElement = ({ size, children }) => (
-  <div className={`list-item__element ${size}`}>{children}</div>
+  <div className={`list-item__element col-${size}`}>{children}</div>
 );
 
 export default ServiceItemElement;
@@ -16,5 +16,5 @@ ServiceItemElement.propTypes = {
 };
 
 ServiceItemElement.defaultProps = {
-  size: '',
+  size: 'md',
 };

--- a/app/javascript/components/ServiceItemElement.js
+++ b/app/javascript/components/ServiceItemElement.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ServiceItemElement = ({ size, children }) => (
+  <div className={`list-item__element ${size}`}>{children}</div>
+);
+
+export default ServiceItemElement;
+
+ServiceItemElement.propTypes = {
+  size: PropTypes.string,
+  children: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+  ]).isRequired,
+};
+
+ServiceItemElement.defaultProps = {
+  size: '',
+};

--- a/app/javascript/components/ServiceList.js
+++ b/app/javascript/components/ServiceList.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ListLabels from './ListLabels';
 
 const ServiceList = ({ children }) => {
   if (children.count === 0) {
@@ -7,15 +8,9 @@ const ServiceList = ({ children }) => {
   }
 
   return (
-    <div className="list-group">
-      <div className="list-group__labels">
-        <div className="list-group__label col-lg">サービス名</div>
-        <div className="list-group__label col-sm">プラン</div>
-        <div className="list-group__label col-sm">料金</div>
-        <div className="list-group__label">更新日</div>
-        <div className="list-group__label">通知日</div>
-      </div>
-      <div className="list-group__inner">
+    <div className="list">
+      <ListLabels />
+      <div className="list__items">
         {children}
       </div>
     </div>


### PR DESCRIPTION
ref #23 

## 概要

- サービス一覧ページに表示される登録サービスのリストをコンポーネントに分割
    - サービス一覧のヘッダをListLabels, ListLabelsItemコンポーネントに分割
    - サービス一覧の個々のリストで表示される部分とボタンを押下することで表示される部分をコンポーネントに分割
        - また、それぞれの表示される項目をServiceItemElementコンポーネントに分割した
- 開閉ボタンを作成
    - 元のPreBillではCSSで表示/非表示を切り替えていたのをReact側で状態をもたせるようにした
    - 状態はServiceItemコンポーネントが持っており、その修正に伴いServiceItemをクラスコンポーネントとして再定義した
- スタイルを追加
    - 基本的には元の実装のスタイルを適用。レスポンシブに対応している部分は省略し、開閉ボタンの状態に応じたスタイルの定義などは適宜修正した。細かい調整は機能の作成を優先し、後日行う予定

## スクリーンショット

[![Image from Gyazo](https://i.gyazo.com/36aa49f1a33ae23a3af93dcf33935cc1.png)](https://gyazo.com/36aa49f1a33ae23a3af93dcf33935cc1)

## 注意事項

マージをadd-button-componentに対して向けているので、先にadd-button-componentがマージされてからmasterに向けてマージをする方が良いと思います。