### PR TITLE
ユーザー認証機能を追加

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -371,6 +371,19 @@ header > .container {
   }
 }
 
+.header-nav__link {
+  font-weight: bold;
+  padding: 2px 7px;
+  font-size: .9rem;
+  color: #fafafa;
+  transition: all ease-out .08s;
+  &:hover {
+    color: white;
+    background-color: rgba(255,255,255,0.2);
+    border-radius: 4px;
+  }
+}
+
 // footer
 
 .footer {

--- a/app/controllers/api/flash_controller.rb
+++ b/app/controllers/api/flash_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::FlashController < ApplicationController
+  skip_before_action :require_login
+
   def index
     respond_to do |format|
       format.json { render json: flash.to_hash }

--- a/app/controllers/api/flash_controller.rb
+++ b/app/controllers/api/flash_controller.rb
@@ -5,7 +5,9 @@ class Api::FlashController < ApplicationController
 
   def index
     respond_to do |format|
-      format.json { render json: flash.to_hash }
+      message = flash.to_hash
+      flash.clear
+      format.json { render json: message }
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,10 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  before_action :require_login
+
+  private
+    def not_authenticated
+      redirect_to root_path, alert: "ログインしてください。"
+    end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class HomeController < ApplicationController
+  skip_before_action :require_login
+
   def index
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,5 +4,8 @@ class HomeController < ApplicationController
   skip_before_action :require_login
 
   def index
+    unless logged_in?
+      render "welcome/index"
+    end
   end
 end

--- a/app/controllers/my_account_controller.rb
+++ b/app/controllers/my_account_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class MyAccountController < ApplicationController
+  skip_before_action :require_login
+
+  def show
+    if logged_in?
+      respond_to do |format|
+        format.json { render json: { name: current_user.name } }
+      end
+    else
+      head :no_content
+    end
+  end
+end

--- a/app/controllers/my_account_controller.rb
+++ b/app/controllers/my_account_controller.rb
@@ -6,7 +6,7 @@ class MyAccountController < ApplicationController
   def show
     if logged_in?
       respond_to do |format|
-        format.json { render json: { name: current_user.name } }
+        format.json { render json: current_user, only: [:name] }
       end
     else
       head :no_content

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,4 +1,20 @@
 # frozen_string_literal: true
 
 class UserSessionsController < ApplicationController
+  def create
+    @user = login(params[:email], params[:password])
+    if @user
+      flash.notice = "ログインしました。"
+      head :ok
+    else
+      flash.alert = "ユーザー名かパスワードが正しくありません。"
+      head :unauthorized
+    end
+  end
+
+  def destroy
+    logout
+    flash.notice = "ログアウトしました。"
+    head :ok
+  end
 end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class UserSessionsController < ApplicationController
+  skip_before_action :require_login, except: :destroy
+
   def create
     @user = login(params[:email], params[:password])
     if @user

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class UserSessionsController < ApplicationController
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,7 @@
 
 class UsersController < ApplicationController
   wrap_parameters :user, include: [:name, :email, :password, :password_confirmation]
+  skip_before_action :require_login
 
   def new
   end

--- a/app/javascript/components/AccountNav.js
+++ b/app/javascript/components/AccountNav.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const AccountNav = () => (
+  <div className="header-nav__items">
+    <div className="header-nav__item">
+      <a href="/signup" className="header-nav__button">アカウント作成</a>
+    </div>
+    <div className="header-nav__item">
+      <a href="/login" className="header-nav__link">ログイン</a>
+    </div>
+  </div>
+);
+
+export default AccountNav;

--- a/app/javascript/components/AuthForm.js
+++ b/app/javascript/components/AuthForm.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Button from './Button';
+
+class AuthForm extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      user: {},
+    };
+
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleInputChange = this.handleInputChange.bind(this);
+  }
+
+  updateUser(key, value) {
+    this.setState((prevState) => ({
+      user: {
+        ...prevState.user,
+        [key]: value,
+      },
+    }));
+  }
+
+  handleSubmit(event) {
+    event.preventDefault();
+    const { user } = this.state;
+    const { onSubmit } = this.props;
+    onSubmit(user);
+  }
+
+  handleInputChange(event) {
+    const { target } = event;
+    const { name, value } = target;
+    this.updateUser(name, value);
+  }
+
+  render() {
+    return (
+      <div className="auth-form__body">
+        <form onSubmit={this.handleSubmit} id="login-form">
+          <div className="form-items--block">
+            <div className="form-item--block">
+              <label htmlFor="user_email">
+                <strong className="form-item__label--block">メールアドレス</strong>
+                <input
+                  name="email"
+                  id="user_email"
+                  onChange={this.handleInputChange}
+                  className="form-item__text-input--block"
+                  placeholder="Eメール"
+                />
+              </label>
+            </div>
+            <div className="form-item--block">
+              <label htmlFor="user_password">
+                <strong className="form-item__label--block">パスワード</strong>
+                <input
+                  type="password"
+                  className="form-item__text-input--block"
+                  id="user_password"
+                  name="password"
+                  onChange={this.handleInputChange}
+                  placeholder="パスワード"
+                />
+              </label>
+            </div>
+          </div>
+          <ul className="form-actions__items">
+            <li className="form-actions__item">
+              <Button
+                onClick={() => { document.getElementById('login-form').dispatchEvent(new Event('submit')); }}
+                size="lg"
+                color="primary"
+                isBlock
+              >
+                ログイン
+              </Button>
+            </li>
+          </ul>
+        </form>
+      </div>
+    );
+  }
+}
+
+export default AuthForm;
+
+AuthForm.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+};

--- a/app/javascript/components/Flash.js
+++ b/app/javascript/components/Flash.js
@@ -59,5 +59,9 @@ class Flash extends React.Component {
 export default Flash;
 
 Flash.propTypes = {
-  services: PropTypes.arrayOf(PropTypes.object).isRequired,
+  services: PropTypes.arrayOf(PropTypes.object),
+};
+
+Flash.defaultProps = {
+  services: undefined,
 };

--- a/app/javascript/components/Header.js
+++ b/app/javascript/components/Header.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import HeaderNav from './HeaderNav';
 
 const Header = () => (
   <header className="header">
@@ -6,13 +7,7 @@ const Header = () => (
       <h1 className="header-title">
         <a href="/" className="header-title__link">PreBill</a>
       </h1>
-      <nav className="header-nav">
-        <div className="header-nav__items">
-          <div className="header-nav__item">
-            <a href="/signup" className="header-nav__button">アカウント作成</a>
-          </div>
-        </div>
-      </nav>
+      <HeaderNav />
     </div>
   </header>
 );

--- a/app/javascript/components/HeaderNav.js
+++ b/app/javascript/components/HeaderNav.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import AccountNav from './AccountNav';
+import UserNav from './UserNav';
+
+class HeaderNav extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      user: null,
+      isLoaded: false,
+    };
+  }
+
+  componentDidMount() {
+    fetch('/my_account.json', {
+      method: 'GET',
+      credentials: 'same-origin',
+    })
+      .then((response) => {
+        if (response.status === 200) {
+          response.json()
+            .then((user) => {
+              this.setState({ user, isLoaded: true });
+            });
+        } else {
+          this.setState({ isLoaded: true });
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+
+  render() {
+    const { user, isLoaded } = this.state;
+
+    if (isLoaded === false) {
+      return null;
+    }
+
+    return (
+      <nav className="header-nav">
+        {user
+          ? <UserNav />
+          : <AccountNav />}
+      </nav>
+    );
+  }
+}
+
+export default HeaderNav;

--- a/app/javascript/components/Login.js
+++ b/app/javascript/components/Login.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import getCsrfToken from '../helpers/getCsrfToken';
+import AuthFormHeader from './AuthFormHeader';
+import AuthFormFooter from './AuthFormFooter';
+import AuthFormFooterLink from './AuthFormFooterLink';
+import AuthForm from './AuthForm';
+import Flash from './Flash';
+
+class Login extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      hasError: false,
+    };
+
+    this.createSession = this.createSession.bind(this);
+  }
+
+  createSession(params) {
+    fetch('/login', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'X-CSRF-Token': getCsrfToken(),
+      },
+      credentials: 'same-origin',
+      body: JSON.stringify(params),
+    })
+      .then((response) => {
+        if (response.ok) {
+          window.location.href = '/';
+        } else {
+          this.setState({ hasError: true });
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+
+  render() {
+    const { hasError } = this.state;
+    return (
+      <>
+        <h1 className="auth-form-logo">
+          <a href="/" className="auth-form-logo__link">PreBill</a>
+        </h1>
+        <div className="auth-form">
+          <AuthFormHeader>ログイン</AuthFormHeader>
+          { hasError && <Flash /> }
+          <AuthForm onSubmit={this.createSession} />
+          <AuthFormFooter>
+            <AuthFormFooterLink href="/">トップページ</AuthFormFooterLink>
+            <AuthFormFooterLink href="/signup">アカウント作成</AuthFormFooterLink>
+          </AuthFormFooter>
+        </div>
+      </>
+    );
+  }
+}
+
+export default Login;

--- a/app/javascript/components/UserNav.js
+++ b/app/javascript/components/UserNav.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import deleteSession from '../helpers/authentication';
+
+const UserNav = () => (
+  <div className="header-nav__items">
+    <div className="header-nav__item">
+      <button type="button" className="header-nav__link" onClick={() => deleteSession()}>ログアウト</button>
+    </div>
+  </div>
+);
+
+export default UserNav;

--- a/app/javascript/helpers/authentication.js
+++ b/app/javascript/helpers/authentication.js
@@ -1,0 +1,22 @@
+import getCsrfToken from './getCsrfToken';
+
+const deleteSession = () => {
+  fetch('/logout', {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'X-CSRF-Token': getCsrfToken(),
+    },
+    credentials: 'same-origin',
+  })
+    .then((response) => {
+      if (response.ok) {
+        window.location.href = '/';
+      }
+    })
+    .catch((error) => {
+      console.error(error);
+    });
+};
+
+export default deleteSession;

--- a/app/javascript/packs/application/welcome.js
+++ b/app/javascript/packs/application/welcome.js
@@ -1,10 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Footer from '../../components/Footer';
+import Flash from '../../components/Flash';
+import Header from '../../components/Header';
 
 const Welcome = ({ children }) => (
   <>
+    <Header />
     <div className="container">
+      <Flash />
       {children}
     </div>
     <Footer />

--- a/app/javascript/packs/application/welcome.js
+++ b/app/javascript/packs/application/welcome.js
@@ -1,14 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Footer from '../../components/Footer';
-import Flash from '../../components/Flash';
 import Header from '../../components/Header';
 
 const Welcome = ({ children }) => (
   <>
     <Header />
     <div className="container">
-      <Flash />
       {children}
     </div>
     <Footer />

--- a/app/javascript/packs/sessions/new.js
+++ b/app/javascript/packs/sessions/new.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from 'react-dom';
+import Welcome from '../application/welcome';
+import Login from '../../components/Login';
+
+const New = () => (
+  <Welcome>
+    <Login />
+  </Welcome>
+);
+
+document.addEventListener('DOMContentLoaded', () => {
+  render(
+    <New />,
+    document.querySelector('#root'),
+  );
+});
+export default New;

--- a/app/javascript/packs/welcome/index.js
+++ b/app/javascript/packs/welcome/index.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import { render } from 'react-dom';
 import Welcome from '../application/welcome';
+import Flash from '../../components/Flash';
 
 const Index = () => (
   <Welcome>
+    <Flash />
     <div>Home#index</div>
   </Welcome>
 );

--- a/app/javascript/packs/welcome/index.js
+++ b/app/javascript/packs/welcome/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render } from 'react-dom';
+import Welcome from '../application/welcome';
+
+const Index = () => (
+  <Welcome>
+    <div>Home#index</div>
+  </Welcome>
+);
+
+document.addEventListener('DOMContentLoaded', () => {
+  render(
+    <Index />,
+    document.querySelector('#root'),
+  );
+});

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,0 +1,2 @@
+<%= javascript_pack_tag 'sessions/new' %>
+<div id="root"></div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,0 +1,2 @@
+<%= javascript_pack_tag 'welcome/index' %>
+<div id="root"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   end
   root to: "home#index"
   resources :services, only: %i(index new create edit update destroy)
+  resource :my_account, only: %i(show), controller: "my_account"
 
   get "signup" => "users#new"
   post "signup" => "users#create"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,7 @@ Rails.application.routes.draw do
 
   get "signup" => "users#new"
   post "signup" => "users#create"
+  get "login" => "user_sessions#new"
+  post "login" => "user_sessions#create"
+  delete "logout" => "user_sessions#destroy"
 end


### PR DESCRIPTION
ref: #7 

## 概要

- ログイン機能を追加
- ログアウト機能を追加
    - ヘッダーにログアウトするボタンを設置
    - コンポーネントの状態を変化させない処理のため、ログアウトする処理はヘルパーに切り出した
        - コンポーネントに定義するとESLintに警告されるため
- 認可を確認するコールバックを定義
    - 認可のないページにアクセスしようとした場合は、トップページにリダイレクトさせ、Flashメッセージを表示
- ログイン状態に応じてヘッダーのナビゲーション表示を切り替える処理を追加
    - 未ログイン時はアカウント作成/ログインページへのリンクを設置した
    - ログイン時はログアウトするボタンを設置
    - 認証済みかどうかを確認するために、MyAccountControllerにユーザー情報を返すAPIを作成
- スタイルを追加

## やらなかったこと

- ログイン時のヘッダーのナビゲーションの実装
    - 現在はページ上でログアウトができるようにするために、ログアウトボタンを設置している。元の実装のような通知欄やドロップダウンの作成は別issueで適宜実装を進める予定。
- ランディングページの作成
    - ログイン状態と未ログイン状態で表示されるページを切り替えられることをページ上で確認できるようにするためにひな形のみ作成した。

## 困っていること

### リロードしてもFlashメッセージが消えないときがある

サービス登録時と修正時にトップページにリダイレクトした後表示されるFlashメッセージがページをリロードしてもメッセージが表示されたままになることがある。

リロードした際にはメッセージは消えた状態になって欲しい。

確認したこと

- リロードするとFlashメッセージが消える時と中々消えない時がある
    - 何度もリロードするとその内消える
- 現在の最新のmasterでは再現しなかった。(リロードすると即メッセージが消えていた)
- 再現したのはサービスの登録時と修正時に表示されるメッセージのみで、他のアクションで表示されるメッセージはリロードすると消える
- Flashを明示的に破棄しようとApi::FlashController#indexの末尾に`flash.discard`を記述しても解決しなかった
- ChromeのDev Toolを確認すると、繰り返しメッセージが表示される時はFlash.jsでfetchしているレスポンスコードが304になっている
    - キャッシュされたメッセージが表示されている?
    - レスポンスコードに応じてReact側の状態を変えようと考えたが、fetchした際に受け取るresponseは200であるためReact側で状態を空のオブジェクトにするのは難しい?

サービス修正後に何度も更新をしてもメッセージが消えない↓

[![Image from Gyazo](https://i.gyazo.com/ef3cbeae25830940067529a8a7f9a186.gif)](https://gyazo.com/ef3cbeae25830940067529a8a7f9a186)

## スクリーンショット

仮のランディングページ(path: "/")

[![Image from Gyazo](https://i.gyazo.com/8fbe19a4c6986a45777f464b0715df11.png)](https://gyazo.com/8fbe19a4c6986a45777f464b0715df11)

ログインページ(path: "/login")

[![Image from Gyazo](https://i.gyazo.com/e8dbbf09269b1a1f07ee264588af95bd.png)](https://gyazo.com/e8dbbf09269b1a1f07ee264588af95bd)

ログイン後のトップページ(サービス一覧ページ)(path: "/")

[![Image from Gyazo](https://i.gyazo.com/9262941f29561f3efbc9e2144ba2f4d7.png)](https://gyazo.com/9262941f29561f3efbc9e2144ba2f4d7)