### PR TITLE
UserとServiceの関連付けを定義

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -4,7 +4,7 @@ class ServicesController < ApplicationController
   before_action :load_service, only: %i(edit update destroy)
 
   def index
-    @services = Service.all
+    @services = current_user.services.all
     respond_to do |format|
       format.json { render json: @services }
     end
@@ -14,7 +14,7 @@ class ServicesController < ApplicationController
   end
 
   def create
-    @service = Service.new(service_params)
+    @service = current_user.services.build(service_params)
     if @service.save
       flash.notice = "サービスを登録しました。"
       head :ok
@@ -63,6 +63,6 @@ class ServicesController < ApplicationController
     end
 
     def load_service
-      @service = Service.find(params[:id])
+      @service = current_user.services.find(params[:id])
     end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -2,6 +2,7 @@
 
 class Service < ApplicationRecord
   enum plan: { monthly: 0, yearly: 1 }
+  belongs_to :user
 
   validates :name, presence: true
   validates :plan, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@
 
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  has_many :services, dependent: :destroy
 
   validates :password, length: { minimum: 6 }, confirmation: true, if: :password_required?
   validates :email, uniqueness: true, presence: true

--- a/db/migrate/20200709061450_add_user_ref_to_services.rb
+++ b/db/migrate/20200709061450_add_user_ref_to_services.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddUserRefToServices < ActiveRecord::Migration[6.0]
+  def up
+    execute "DELETE FROM services;"
+    add_reference :services, :user, null: false, foreign_key: true, index: true
+  end
+
+  def down
+    remove_reference :services, :user, index: true
+  end
+end

--- a/db/migrate/20200709061450_add_user_ref_to_services.rb
+++ b/db/migrate/20200709061450_add_user_ref_to_services.rb
@@ -1,12 +1,7 @@
 # frozen_string_literal: true
 
 class AddUserRefToServices < ActiveRecord::Migration[6.0]
-  def up
-    execute "DELETE FROM services;"
-    add_reference :services, :user, null: false, foreign_key: true, index: true
-  end
-
-  def down
-    remove_reference :services, :user, index: true
+  def change
+    add_reference :services, :user, foreign_key: true, index: true
   end
 end

--- a/db/migrate/20200710051127_add_not_null_constraint_to_user_id.rb
+++ b/db/migrate/20200710051127_add_not_null_constraint_to_user_id.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotNullConstraintToUserId < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :services, :user_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_03_084251) do
+ActiveRecord::Schema.define(version: 2020_07_09_061450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -25,6 +25,8 @@ ActiveRecord::Schema.define(version: 2020_07_03_084251) do
     t.date "remind_on"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_services_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -36,4 +38,6 @@ ActiveRecord::Schema.define(version: 2020_07_03_084251) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
+
+  add_foreign_key "services", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_09_061450) do
+ActiveRecord::Schema.define(version: 2020_07_10_051127) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/lib/tasks/associate_services.rake
+++ b/lib/tasks/associate_services.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+namespace :associate_services do
+  desc "update services associated with a user"
+  task services: :environment do
+    puts "Add user_id to services..."
+    user = User.first_or_create!(
+      name: "shoynoi",
+      email: "shoynoi@example.com",
+      password: "password",
+      password_confirmation: "password"
+    )
+    Service.update_all(user_id: user.id)
+    puts "Finished."
+  end
+end


### PR DESCRIPTION
ref: #10 

## 概要

- Serviceモデルにuser_idを追加
- UserモデルとServiceモデルに関連付けを定義
- それぞれのユーザーと関連するサービスのみを操作できるようにコンロトーラを修正

## 注意事項

add-authentication(#52)がマージされてからマージする