### PR TITLE
サービスの登録ページと修正ページの両方でSubmitボタンが「登録」と表示されていたのを修正

### DIFF
--- a/app/javascript/components/EditService.js
+++ b/app/javascript/components/EditService.js
@@ -69,7 +69,9 @@ class EditService extends React.Component {
           service={service}
           onSubmit={this.updateService}
           errorMessages={errorMessages}
-        />
+        >
+          修正
+        </ServiceForm>
       </div>
     );
   }

--- a/app/javascript/components/EditService.js
+++ b/app/javascript/components/EditService.js
@@ -69,9 +69,8 @@ class EditService extends React.Component {
           service={service}
           onSubmit={this.updateService}
           errorMessages={errorMessages}
-        >
-          修正
-        </ServiceForm>
+          action="update"
+        />
       </div>
     );
   }

--- a/app/javascript/components/NewService.js
+++ b/app/javascript/components/NewService.js
@@ -42,7 +42,9 @@ class NewService extends React.Component {
     const { errorMessages } = this.state;
     return (
       <div>
-        <ServiceForm onSubmit={this.createService} errorMessages={errorMessages} />
+        <ServiceForm onSubmit={this.createService} errorMessages={errorMessages}>
+          登録
+        </ServiceForm>
       </div>
     );
   }

--- a/app/javascript/components/NewService.js
+++ b/app/javascript/components/NewService.js
@@ -42,9 +42,11 @@ class NewService extends React.Component {
     const { errorMessages } = this.state;
     return (
       <div>
-        <ServiceForm onSubmit={this.createService} errorMessages={errorMessages}>
-          登録
-        </ServiceForm>
+        <ServiceForm
+          onSubmit={this.createService}
+          errorMessages={errorMessages}
+          action="create"
+        />
       </div>
     );
   }

--- a/app/javascript/components/ServiceForm.js
+++ b/app/javascript/components/ServiceForm.js
@@ -40,7 +40,8 @@ class ServiceForm extends React.Component {
 
   render() {
     const { service } = this.state;
-    const { errorMessages, children } = this.props;
+    const { errorMessages, action } = this.props;
+    const buttonLabel = action === 'create' ? '登録' : '修正';
 
     return (
       <div>
@@ -140,7 +141,7 @@ class ServiceForm extends React.Component {
                 size="md"
                 isBlock
               >
-                {children}
+                {buttonLabel}
               </Button>
             </li>
             <li className="form-actions__item--cancel">
@@ -166,6 +167,7 @@ ServiceForm.propTypes = {
   }),
   onSubmit: PropTypes.func.isRequired,
   errorMessages: PropTypes.arrayOf(PropTypes.string),
+  action: PropTypes.string.isRequired,
 };
 
 ServiceForm.defaultProps = {

--- a/app/javascript/components/ServiceForm.js
+++ b/app/javascript/components/ServiceForm.js
@@ -40,7 +40,7 @@ class ServiceForm extends React.Component {
 
   render() {
     const { service } = this.state;
-    const { errorMessages } = this.props;
+    const { errorMessages, children } = this.props;
 
     return (
       <div>
@@ -140,7 +140,7 @@ class ServiceForm extends React.Component {
                 size="md"
                 isBlock
               >
-                登録
+                {children}
               </Button>
             </li>
             <li className="form-actions__item--cancel">


### PR DESCRIPTION
## 概要

- 現在、サービスの登録ページと修正ページで同じServiceFormコンポーネントを利用している。
    - ServiceFormコンポーネント内のSubmitボタンがどちらのページでも同じ「登録」が表示されていたので、修正ページでは「修正」と表示されるようにボタンに表示される文言を親コンポーネントから指定できるようにした

## スクリーンショット

登録ページ

[![Image from Gyazo](https://i.gyazo.com/f67a3198f663ce1b8460c3cef5f40d95.png)](https://gyazo.com/f67a3198f663ce1b8460c3cef5f40d95)

修正ページ

[![Image from Gyazo](https://i.gyazo.com/40e4a2ce549477eb8a816cede87b6e04.png)](https://gyazo.com/40e4a2ce549477eb8a816cede87b6e04)