### PR TITLE
ユーザー情報更新機能を作成

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -384,6 +384,71 @@ header > .container {
   }
 }
 
+.header-menu {
+  height: 100%;
+}
+
+.header-menu__label {
+  display: flex;
+  align-items: center;
+  height: 100%;
+}
+
+.header-menu__button {
+  font-weight: bold;
+  padding: 2px 7px;
+  color: #fafafa;
+  &:hover {
+    color: white;
+    background-color: rgba(255,255,255,0.2);
+    border-radius: 4px;
+  }
+  &:focus {
+    outline: none;
+  }
+}
+
+.header-menu__icon {
+  margin-left: .3rem;
+}
+
+.header-dropdown {
+  position: absolute;
+  right: 0;
+  z-index: 2;
+  border: 1px solid rgba(34, 36, 38, .2);
+  border-radius: .25rem;
+  box-shadow: 0 1px 8px 0 rgba(0, 0, 0, 0.2);
+  width: 10rem;
+  background-color: white;
+}
+
+.header-dropdown__items {
+  list-style: none;
+  > :not(:last-of-type) {
+    border-bottom: 1px solid #ddd;
+  }
+}
+
+.header-dropdown__item {
+  font-size: .875rem;
+  transition: all ease-out .2s;
+  &:hover {
+    background-color: #E5E5E5;
+  }
+}
+
+.header-dropdown__link {
+  display: block;
+  padding: .75rem;
+  width: 100%;
+  text-align: left;
+  color: $blue;
+  &:focus {
+    outline: none;
+  }
+}
+
 // footer
 
 .footer {

--- a/app/controllers/my_account_controller.rb
+++ b/app/controllers/my_account_controller.rb
@@ -2,6 +2,9 @@
 
 class MyAccountController < ApplicationController
   skip_before_action :require_login
+  before_action :set_user, only: %i(update)
+
+  wrap_parameters :user, include: [:name, :email, :password, :password_confirmation]
 
   def show
     if logged_in?
@@ -12,4 +15,32 @@ class MyAccountController < ApplicationController
       head :no_content
     end
   end
+
+  def edit
+  end
+
+  def update
+    if @user.update(user_params)
+      flash.notice = "ユーザー情報を変更しました。"
+      head :ok
+    else
+      respond_to do |format|
+        format.json { render json: @user.errors.full_messages, status: 422 }
+      end
+    end
+  end
+
+  private
+    def user_params
+      params.require(:user).permit(
+        :name,
+        :email,
+        :password,
+        :password_confirmation
+      )
+    end
+
+    def set_user
+      @user = current_user
+    end
 end

--- a/app/controllers/my_account_controller.rb
+++ b/app/controllers/my_account_controller.rb
@@ -9,7 +9,7 @@ class MyAccountController < ApplicationController
   def show
     if logged_in?
       respond_to do |format|
-        format.json { render json: current_user, only: [:name] }
+        format.json { render json: current_user, only: [:name, :email] }
       end
     else
       head :no_content

--- a/app/javascript/components/AccountForm.js
+++ b/app/javascript/components/AccountForm.js
@@ -38,8 +38,9 @@ class AccountForm extends React.Component {
   }
 
   render() {
-    const { errorMessages } = this.props;
+    const { errorMessages, action } = this.props;
     const { user } = this.state;
+    const buttonLabel = action === 'create' ? 'アカウントを作成する' : '更新する';
 
     return (
 
@@ -110,7 +111,7 @@ class AccountForm extends React.Component {
                 color="primary"
                 block="block"
               >
-                アカウントを作成する
+                {buttonLabel}
               </Button>
             </li>
           </ul>
@@ -126,6 +127,7 @@ AccountForm.propTypes = {
   user: PropTypes.objectOf(PropTypes.string),
   onSubmit: PropTypes.func.isRequired,
   errorMessages: PropTypes.arrayOf(PropTypes.string),
+  action: PropTypes.string.isRequired,
 };
 
 AccountForm.defaultProps = {

--- a/app/javascript/components/AccountForm.js
+++ b/app/javascript/components/AccountForm.js
@@ -39,6 +39,7 @@ class AccountForm extends React.Component {
 
   render() {
     const { errorMessages } = this.props;
+    const { user } = this.state;
 
     return (
 
@@ -55,6 +56,7 @@ class AccountForm extends React.Component {
                   id="user_name"
                   name="name"
                   placeholder="ユーザー名"
+                  value={user.name}
                   onChange={this.handleInputChange}
                 />
               </label>
@@ -68,6 +70,7 @@ class AccountForm extends React.Component {
                   onChange={this.handleInputChange}
                   className="form-item__text-input--block"
                   placeholder="Eメール"
+                  value={user.email}
                 />
               </label>
             </div>

--- a/app/javascript/components/AccountForm.js
+++ b/app/javascript/components/AccountForm.js
@@ -109,7 +109,7 @@ class AccountForm extends React.Component {
                 onClick={() => { document.getElementById('user-form').dispatchEvent(new Event('submit')); }}
                 size="lg"
                 color="primary"
-                block="block"
+                isBlock
               >
                 {buttonLabel}
               </Button>

--- a/app/javascript/components/EditUser.js
+++ b/app/javascript/components/EditUser.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import getCsrfToken from '../helpers/getCsrfToken';
+import AccountForm from './AccountForm';
+import AuthFormFooter from './AuthFormFooter';
+import AuthFormFooterLink from './AuthFormFooterLink';
+import PageHeader from './PageHeader';
+import PageHeaderTitle from './PageHeaderTitle';
+import LinkButton from './LinkButton';
+
+class EditUser extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      currentUser: null,
+      errorMessages: [],
+    };
+
+    this.updateUser = this.updateUser.bind(this);
+  }
+
+  componentDidMount() {
+    fetch('/my_account.json', {
+      method: 'GET',
+      credentials: 'same-origin',
+    })
+      .then((response) => {
+        response.json()
+          .then((currentUser) => {
+            this.setState({ currentUser });
+          });
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+
+  updateUser(editedUser) {
+    fetch('/my_account', {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'X-CSRF-Token': getCsrfToken(),
+      },
+      credentials: 'same-origin',
+      body: JSON.stringify(editedUser),
+    })
+      .then((response) => {
+        if (response.ok) {
+          window.location.href = '/';
+        } else {
+          response.json()
+            .then((errorMessages) => {
+              this.setState({ errorMessages });
+            });
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+
+  render() {
+    const { errorMessages, currentUser } = this.state;
+
+    if (currentUser === null) return null;
+
+    return (
+      <>
+        <PageHeader>
+          <PageHeaderTitle>ユーザー設定</PageHeaderTitle>
+          <div className="page-header__action">
+            <LinkButton href="/" color="secondary" size="md">一覧</LinkButton>
+          </div>
+        </PageHeader>
+        <div className="auth-form--is-update">
+          <AccountForm
+            onSubmit={this.updateUser}
+            errorMessages={errorMessages}
+            action="update"
+            user={currentUser}
+          />
+          <AuthFormFooter>
+            <AuthFormFooterLink href="/">トップページ</AuthFormFooterLink>
+            {/* TODO アカウント削除ページを作成する */}
+            <AuthFormFooterLink href="/close">アカウント削除</AuthFormFooterLink>
+          </AuthFormFooter>
+        </div>
+      </>
+    );
+  }
+}
+
+export default EditUser;

--- a/app/javascript/components/HeaderMenu.js
+++ b/app/javascript/components/HeaderMenu.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCaretDown } from '@fortawesome/free-solid-svg-icons';
 import onClickOutside from 'react-onclickoutside';
 import deleteSession from '../helpers/authentication';
 
@@ -36,6 +38,7 @@ class HeaderMenu extends React.Component {
             onClick={this.toggleDropdown}
           >
             {user.name}
+            <span className="header-menu__icon"><FontAwesomeIcon icon={faCaretDown} /></span>
           </button>
         </div>
         {

--- a/app/javascript/components/HeaderMenu.js
+++ b/app/javascript/components/HeaderMenu.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import onClickOutside from 'react-onclickoutside';
+import deleteSession from '../helpers/authentication';
+
+class HeaderMenu extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isOpen: false,
+    };
+    this.toggleDropdown = this.toggleDropdown.bind(this);
+  }
+
+  toggleDropdown() {
+    const { isOpen } = this.state;
+    this.setState({ isOpen: !isOpen });
+  }
+
+  handleClickOutside() {
+    this.setState({ isOpen: false });
+  }
+
+  render() {
+    const { user } = this.props;
+    const { isOpen } = this.state;
+
+    if (!user) return null;
+
+    return (
+      <div className="header-menu">
+        <div className="header-menu__label">
+          <button
+            type="button"
+            className="header-menu__button"
+            onClick={this.toggleDropdown}
+          >
+            {user.name}
+          </button>
+        </div>
+        {
+          isOpen
+            && (
+            <div className="header-dropdown">
+              <ul className="header-dropdown__items">
+                <li className="header-dropdown__item">
+                  <a href="/my_account/edit" className="header-dropdown__link">ユーザー設定</a>
+                </li>
+                <li className="header-dropdown__item">
+                  <button
+                    type="button"
+                    className="header-dropdown__link"
+                    onClick={() => deleteSession()}
+                  >
+                    ログアウト
+                  </button>
+                </li>
+              </ul>
+            </div>
+            )
+        }
+      </div>
+    );
+  }
+}
+
+export default onClickOutside(HeaderMenu);
+
+HeaderMenu.propTypes = {
+  user: PropTypes.objectOf(PropTypes.string).isRequired,
+};

--- a/app/javascript/components/HeaderNav.js
+++ b/app/javascript/components/HeaderNav.js
@@ -41,7 +41,7 @@ class HeaderNav extends React.Component {
     return (
       <nav className="header-nav">
         {user
-          ? <UserNav />
+          ? <UserNav user={user} />
           : <AccountNav />}
       </nav>
     );

--- a/app/javascript/components/NewUser.js
+++ b/app/javascript/components/NewUser.js
@@ -50,7 +50,11 @@ class NewUser extends React.Component {
         </h1>
         <div className="auth-form">
           <AuthFormHeader>アカウント作成</AuthFormHeader>
-          <AccountForm onSubmit={this.createUser} errorMessages={errorMessages} />
+          <AccountForm
+            onSubmit={this.createUser}
+            errorMessages={errorMessages}
+            action="create"
+          />
           <AuthFormFooter>
             <AuthFormFooterLink href="/">トップページ</AuthFormFooterLink>
             <AuthFormFooterLink href="/login">ログイン</AuthFormFooterLink>

--- a/app/javascript/components/UserNav.js
+++ b/app/javascript/components/UserNav.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import deleteSession from '../helpers/authentication';
 
-const UserNav = () => (
+const UserNav = ({ user }) => (
   <div className="header-nav__items">
     <div className="header-nav__item">
-      <button type="button" className="header-nav__link" onClick={() => deleteSession()}>ログアウト</button>
+      <HeaderMenu user={user} />
     </div>
   </div>
 );

--- a/app/javascript/components/UserNav.js
+++ b/app/javascript/components/UserNav.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import deleteSession from '../helpers/authentication';
+import PropTypes from 'prop-types';
+import HeaderMenu from './HeaderMenu';
 
 const UserNav = ({ user }) => (
   <div className="header-nav__items">
@@ -10,3 +11,7 @@ const UserNav = ({ user }) => (
 );
 
 export default UserNav;
+
+UserNav.propTypes = {
+  user: PropTypes.objectOf(PropTypes.string).isRequired,
+};

--- a/app/javascript/packs/my_account/edit.js
+++ b/app/javascript/packs/my_account/edit.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { render } from 'react-dom';
+import App from '../application/app';
+import EditUser from '../../components/EditUser';
+
+const Edit = () => (
+  <App>
+    <main className="page">
+      <EditUser />
+    </main>
+  </App>
+);
+
+document.addEventListener('DOMContentLoaded', () => {
+  render(
+    <Edit />,
+    document.querySelector('#root'),
+  );
+});

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,11 +5,12 @@ class User < ApplicationRecord
   has_many :services, dependent: :destroy
 
   validates :password, length: { minimum: 6 }, confirmation: true, if: :password_required?
+  validates :password_confirmation, presence: true, if: :password_required?
   validates :email, uniqueness: true, presence: true
   validates :name, presence: true
 
   private
     def password_required?
-      new_record? || password.present?
+      new_record? || password.present? || password_confirmation.present?
     end
 end

--- a/app/views/my_account/edit.html.erb
+++ b/app/views/my_account/edit.html.erb
@@ -1,0 +1,2 @@
+<%= javascript_pack_tag 'my_account/edit' %>
+<div id="root"></div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   end
   root to: "home#index"
   resources :services, only: %i(index new create edit update destroy)
-  resource :my_account, only: %i(show), controller: "my_account"
+  resource :my_account, only: %i(show edit update), controller: "my_account"
 
   get "signup" => "users#new"
   post "signup" => "users#create"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "linkifyjs": "^2.1.9",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
-    "react-dom": "^16.13.1"
+    "react-dom": "^16.13.1",
+    "react-onclickoutside": "^6.9.0"
   },
   "version": "0.1.0",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "dependencies": {
     "@babel/preset-react": "^7.10.1",
+    "@fortawesome/fontawesome-svg-core": "^1.2.29",
+    "@fortawesome/free-solid-svg-icons": "^5.13.1",
+    "@fortawesome/react-fontawesome": "^0.1.11",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6626,6 +6626,11 @@ react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-onclickoutside@^6.9.0:
+  version "6.9.0"
+  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.9.0.tgz#a54bc317ae8cf6131a5d78acea55a11067f37a1f"
+  integrity sha512-8ltIY3bC7oGhj2nPAvWOGi+xGFybPNhJM0V1H8hY/whNcXgmDeaeoCMPPd8VatrpTsUWjb/vGzrmu6SrXVty3A==
+
 react@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -899,6 +899,32 @@
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
 
+"@fortawesome/fontawesome-common-types@^0.2.29":
+  version "0.2.29"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.29.tgz#e1a456b643237462d390304cab6975ff3fd68397"
+  integrity sha512-cY+QfDTbZ7XVxzx7jxbC98Oxr/zc7R2QpTLqTxqlfyXDrAJjzi/xUIqAUsygELB62JIrbsWxtSRhayKFkGI7MA==
+
+"@fortawesome/fontawesome-svg-core@^1.2.29":
+  version "1.2.29"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.29.tgz#34ef32824664534f9e4ef37982ebf286b899a189"
+  integrity sha512-xmPmP2t8qrdo8RyKihTkGb09RnZoc+7HFBCnr0/6ZhStdGDSLeEd7ajV181+2W29NWIFfylO13rU+s3fpy3cnA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.29"
+
+"@fortawesome/free-solid-svg-icons@^5.13.1":
+  version "5.13.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.13.1.tgz#010a846b718a0f110b3cd137d072639b4e8bd41a"
+  integrity sha512-LQH/0L1p4+rqtoSHa9qFYR84hpuRZKqaQ41cfBQx8b68p21zoWSekTAeA54I/2x9VlCHDLFlG74Nmdg4iTPQOg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.29"
+
+"@fortawesome/react-fontawesome@^0.1.11":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.11.tgz#c1a95a2bdb6a18fa97b355a563832e248bf6ef4a"
+  integrity sha512-sClfojasRifQKI0OPqTy8Ln8iIhnxR/Pv/hukBhWnBz9kQRmqi6JSH3nghlhAY7SUeIIM7B5/D2G8WjX0iepVg==
+  dependencies:
+    prop-types "^15.7.2"
+
 "@rails/ujs@^6.0.0":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-6.0.3.tgz#e68a03278e30daea6a110aac5dfa33c60c53055d"


### PR DESCRIPTION
ref: #8 

## 概要

- ユーザー情報を更新するAPIを作成
- ユーザー情報更新ページの作成
    - テンプレートファイルを作成
    - EditUserコンポーネントを作成
        - EdiuUserコンポーネントのフッターに表示されるアカウント削除リンクのページについては後日実装予定
- バリデーションの修正
    - パスワードもしくはパスワード(確認)のどちらか一方のみを入力した状態で更新すると処理が成功してしまっていたため、Userモデルのバリデーションを修正し、ユーザー情報編集時にパスワードを変更する場合(passwordもしくはpassword_confirmationを入力している場合)は、どちらも入力しないとエラーが表示されるようにした
- ヘッダーのドロップダウンの実装
    - ヘッダーに表示されるユーザー名をクリックするとメニューが表示され、ユーザー情報変更ページへのリンクとログアウトボタンが表示される
    - ユーザー名の横にCaret Downアイコンを配置するためにreact-fontawesomeを導入
    - メニューの開閉はボタンのクリックにより行われる。メニューが表示されている状態でメニュー外をクリックすることで自動的に閉じられるようにするため、react-onlickoutsideを導入した

## スクリーンショット

[![Image from Gyazo](https://i.gyazo.com/2df627436d4f1f192217aa7027dade83.png)](https://gyazo.com/2df627436d4f1f192217aa7027dade83)