### PR TITLE
アカウントの作成が完了したらログイン状態となるように修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       flash.notice = "アカウントを作成しました。"
+      auto_login(@user)
       head :ok
     else
       respond_to do |format|


### PR DESCRIPTION
ref: #57 

## 概要

アカウントを作成した後にトップページにリダイレクトされ、自動的にログイン状態となるように修正