### PR TITLE
サービス一覧ページに表示される更新日が次回の更新日を表示するように修正

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -6,7 +6,7 @@ class ServicesController < ApplicationController
   def index
     @services = current_user.services.all
     respond_to do |format|
-      format.json { render json: @services }
+      format.json { render json: @services.map { |service| service.as_json.merge(next_renewed_on: service.next_renewed_on) } }
     end
   end
 

--- a/app/javascript/components/ListDisplayedItem.js
+++ b/app/javascript/components/ListDisplayedItem.js
@@ -11,7 +11,7 @@ const ListDisplayedItem = ({ service, onClick, isExpand }) => (
     </ServiceItemElement>
     <ServiceItemElement size="sm">{formatPlan(service.plan)}</ServiceItemElement>
     <ServiceItemElement size="sm">{formatPrice(service.price)}</ServiceItemElement>
-    <ServiceItemElement>{formatDate(service.renewed_on)}</ServiceItemElement>
+    <ServiceItemElement>{formatDate(service.next_renewed_on)}</ServiceItemElement>
     <ServiceItemElement>{formatDate(service.remind_on)}</ServiceItemElement>
     <ExpandButton onClick={onClick} isExpand={isExpand} />
   </div>
@@ -26,6 +26,7 @@ ListDisplayedItem.propTypes = {
     plan: PropTypes.string,
     price: PropTypes.number,
     renewed_on: PropTypes.string,
+    next_renewed_on: PropTypes.string,
     remind_on: PropTypes.string,
   }),
   onClick: PropTypes.func.isRequired,


### PR DESCRIPTION
ref: #60

## 概要

現在、サービス一覧ページに表示されている更新日は登録時に指定した日時(renewed_on)が常に表示されるようになっている。
#59 で実装した`next_renewed_on`を利用して更新日を過ぎたら次回の更新日が表示されるように修正した。

元の実装も含め、今のところサービス毎の更新日と同期する方法がわからなかったので、翌月(年)の同じ日付を更新日としている。

また、例えばプランが月額の場合で登録日が31日で、翌月の月末が28日の場合は、28日が更新日となり、さらにその翌月が31日の場合は、31日が更新日となるような実装になっている。

## 注意事項

マージは #59 がマージされてからになります。