### PR TITLE
アプリ内通知機能を追加

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -429,14 +429,16 @@ header > .container {
 
 .header-dropdown__items {
   list-style: none;
-  > :not(:last-of-type) {
-    border-bottom: 1px solid #ddd;
+  &.is-notification {
+    overflow-y: scroll;
+    height: 50vh;
   }
 }
 
 .header-dropdown__item {
   font-size: .875rem;
   transition: all ease-out .2s;
+  border-bottom: 1px solid #ddd;
   &:hover {
     background-color: #E5E5E5;
   }

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -422,6 +422,9 @@ header > .container {
   box-shadow: 0 1px 8px 0 rgba(0, 0, 0, 0.2);
   width: 10rem;
   background-color: white;
+  &.is-notification {
+    width: 20rem;
+  }
 }
 
 .header-dropdown__items {
@@ -448,6 +451,86 @@ header > .container {
   &:focus {
     outline: none;
   }
+}
+
+.header-dropdown__header {
+  font-size: .875rem;
+  font-weight: bold;
+  padding: .5rem;
+  border-bottom: 1px solid rgba(34, 36, 38, 0.2);
+}
+
+.header-dropdown__container {
+  display: flex;
+  padding: .75rem;
+}
+
+.header-dropdown__text-holder {
+  margin-left: .5rem;
+}
+
+.header-dropdown__text {
+  white-space: pre-line;
+  font-size: .85rem;
+}
+
+.header-dropdown__time-holder {
+  font-size: .75rem;
+  color: gray;
+}
+
+.header-dropdown__unread-icon {
+  flex-basis: 10%;
+  align-self: center;
+  &::after {
+    content: "";
+    display: block;
+    width: 7px;
+    height: 7px;
+    background-color: #1A5084;
+    border-radius: 50%;
+    margin: 0 auto;
+  }
+  &.is-read {
+    visibility: hidden;
+  }
+}
+
+.header-notification {
+  height: 100%;
+}
+
+.header-notification__icon {
+  padding: 2px 7px;
+  color: #fafafa;
+  cursor: pointer;
+  position: relative;
+  outline: none;
+  &:hover {
+    color: white;
+    background-color: rgba(255,255,255,0.2);
+    border-radius: 4px;
+  }
+}
+
+.header-notification__label {
+  display: flex;
+  align-items: center;
+  height: 100%;
+}
+
+.header-notification__header {
+  padding: .5rem 1rem;
+}
+
+.header-notification__badge {
+  background: red;
+  width: .5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  position: absolute;
+  right: .25rem;
+  top: .25rem;
 }
 
 // footer

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -3,9 +3,6 @@
 class Api::NotificationsController < ApplicationController
   def index
     @notifications = current_user.notifications.recent
-    respond_to do |format|
-      format.json { render json: @notifications, only: [:id, :read, :message, :created_at] }
-    end
   end
 
   def update

--- a/app/controllers/api/notifications_controller.rb
+++ b/app/controllers/api/notifications_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Api::NotificationsController < ApplicationController
+  def index
+    @notifications = current_user.notifications.recent
+    respond_to do |format|
+      format.json { render json: @notifications, only: [:id, :read, :message, :created_at] }
+    end
+  end
+
+  def update
+    @notification = current_user.notifications.find_by(id: params[:id])
+    if @notification.update(read: true)
+      head :ok
+    end
+  end
+end

--- a/app/javascript/components/Header.js
+++ b/app/javascript/components/Header.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import HeaderNav from './HeaderNav';
 
 const Header = ({ services }) => (
@@ -13,3 +14,11 @@ const Header = ({ services }) => (
 );
 
 export default Header;
+
+Header.propTypes = {
+  services: PropTypes.arrayOf(PropTypes.object),
+};
+
+Header.defaultProps = {
+  services: [],
+};

--- a/app/javascript/components/Header.js
+++ b/app/javascript/components/Header.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import HeaderNav from './HeaderNav';
 
-const Header = () => (
+const Header = ({ services }) => (
   <header className="header">
     <div className="container">
       <h1 className="header-title">
         <a href="/" className="header-title__link">PreBill</a>
       </h1>
-      <HeaderNav />
+      <HeaderNav services={services} />
     </div>
   </header>
 );

--- a/app/javascript/components/HeaderNav.js
+++ b/app/javascript/components/HeaderNav.js
@@ -33,6 +33,7 @@ class HeaderNav extends React.Component {
 
   render() {
     const { user, isLoaded } = this.state;
+    const { services } = this.props;
 
     if (isLoaded === false) {
       return null;
@@ -41,7 +42,7 @@ class HeaderNav extends React.Component {
     return (
       <nav className="header-nav">
         {user
-          ? <UserNav user={user} />
+          ? <UserNav user={user} services={services} />
           : <AccountNav />}
       </nav>
     );

--- a/app/javascript/components/HeaderNav.js
+++ b/app/javascript/components/HeaderNav.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import AccountNav from './AccountNav';
 import UserNav from './UserNav';
 
@@ -50,3 +51,11 @@ class HeaderNav extends React.Component {
 }
 
 export default HeaderNav;
+
+HeaderNav.propTypes = {
+  services: PropTypes.arrayOf(PropTypes.object),
+};
+
+HeaderNav.defaultProps = {
+  services: [],
+};

--- a/app/javascript/components/Notification.js
+++ b/app/javascript/components/Notification.js
@@ -14,6 +14,17 @@ class Notification extends React.Component {
   }
 
   componentDidMount() {
+    this.fetchNotifications();
+  }
+
+  componentDidUpdate(prevProps) {
+    const { services } = this.props;
+    if (prevProps.services !== services) {
+      this.fetchNotifications();
+    }
+  }
+
+  fetchNotifications() {
     fetch('/api/notifications', {
       method: 'GET',
       credentials: 'same-origin',

--- a/app/javascript/components/Notification.js
+++ b/app/javascript/components/Notification.js
@@ -81,11 +81,11 @@ class Notification extends React.Component {
 
     if (notifications === null) return null;
 
-    const hasUnRead = notifications.some((notification) => !notification.read);
+    const hasUnread = notifications.some((notification) => !notification.read);
 
     return (
       <div className="header-notification">
-        <NotificationIcon onClick={this.toggleDropdown} hasUnRead={hasUnRead} />
+        <NotificationIcon onClick={this.toggleDropdown} hasUnread={hasUnread} />
         { isOpen
         && (
           <NotificationList

--- a/app/javascript/components/Notification.js
+++ b/app/javascript/components/Notification.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import NotificationIcon from './NotificationIcon';
+import NotificationList from './NotificationList';
+import getCsrfToken from '../helpers/getCsrfToken';
+
+class Notification extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      notifications: null,
+    };
+    this.toggleDropdown = this.toggleDropdown.bind(this);
+    this.markAsRead = this.markAsRead.bind(this);
+  }
+
+  componentDidMount() {
+    fetch('/api/notifications', {
+      method: 'GET',
+      credentials: 'same-origin',
+    })
+      .then((response) => {
+        response.json()
+          .then((notifications) => {
+            this.setState({ notifications });
+          });
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+
+  toggleDropdown() {
+    const { isOpen } = this.state;
+    this.setState({ isOpen: !isOpen });
+  }
+
+  markAsRead(notification) {
+    if (notification.read) return;
+    fetch(`/api/notifications/${notification.id}`, {
+      method: 'PATCH',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'X-CSRF-Token': getCsrfToken(),
+      },
+    })
+      .then((response) => {
+        if (response.ok) {
+          const { notifications } = this.state;
+          const updatedNotifications = notifications.map((prevNotification) => (
+            prevNotification.id === notification.id
+              ? { ...notification, read: true }
+              : prevNotification
+          ));
+          this.setState({
+            notifications: [
+              ...updatedNotifications,
+            ],
+          });
+        }
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+
+  render() {
+    const { notifications, isOpen } = this.state;
+
+    if (notifications === null) return null;
+
+    const hasUnRead = notifications.some((notification) => !notification.read);
+
+    return (
+      <div className="header-notification">
+        <NotificationIcon onClick={this.toggleDropdown} hasUnRead={hasUnRead} />
+        { isOpen
+        && (
+          <NotificationList
+            notifications={notifications}
+            eventTypes={['click', 'touchstart']}
+            closeDropdown={() => this.setState({ isOpen: false })}
+            onClick={this.markAsRead}
+          />
+        )}
+      </div>
+    );
+  }
+}
+
+export default Notification;

--- a/app/javascript/components/Notification.js
+++ b/app/javascript/components/Notification.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import NotificationIcon from './NotificationIcon';
 import NotificationList from './NotificationList';
 import getCsrfToken from '../helpers/getCsrfToken';
@@ -100,3 +101,11 @@ class Notification extends React.Component {
 }
 
 export default Notification;
+
+Notification.propTypes = {
+  services: PropTypes.arrayOf(PropTypes.object),
+};
+
+Notification.defaultProps = {
+  services: [],
+};

--- a/app/javascript/components/NotificationIcon.js
+++ b/app/javascript/components/NotificationIcon.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBell } from '@fortawesome/free-solid-svg-icons';
+
+const NotificationIcon = ({ onClick, hasUnRead }) => (
+  <div className="header-notification__label">
+    <button type="button" className="header-notification__icon" onClick={onClick}>
+      <i className={hasUnRead ? 'header-notification__badge' : ''} />
+      <FontAwesomeIcon icon={faBell} />
+    </button>
+  </div>
+);
+
+export default NotificationIcon;
+
+NotificationIcon.propTypes = {
+  onClick: PropTypes.func.isRequired,
+  hasUnRead: PropTypes.bool.isRequired,
+};

--- a/app/javascript/components/NotificationIcon.js
+++ b/app/javascript/components/NotificationIcon.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faBell } from '@fortawesome/free-solid-svg-icons';
 
-const NotificationIcon = ({ onClick, hasUnRead }) => (
+const NotificationIcon = ({ onClick, hasUnread }) => (
   <div className="header-notification__label">
     <button type="button" className="header-notification__icon" onClick={onClick}>
-      <i className={hasUnRead ? 'header-notification__badge' : ''} />
+      <i className={hasUnread ? 'header-notification__badge' : ''} />
       <FontAwesomeIcon icon={faBell} />
     </button>
   </div>
@@ -16,5 +16,5 @@ export default NotificationIcon;
 
 NotificationIcon.propTypes = {
   onClick: PropTypes.func.isRequired,
-  hasUnRead: PropTypes.bool.isRequired,
+  hasUnread: PropTypes.bool.isRequired,
 };

--- a/app/javascript/components/NotificationItem.js
+++ b/app/javascript/components/NotificationItem.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const NotificationItem = ({ notification, onClick }) => (
+  <li className="header-dropdown__item" onClick={() => onClick(notification)}>
+    <div className="header-dropdown__container">
+      <div className={`header-dropdown__unread-icon ${notification.read ? 'is-read' : ''}`} />
+      <div className="header-dropdown__text-holder">
+        <p className="header-dropdown__text">
+          {notification.message}
+        </p>
+        <time className="header-dropdown__time-holder">
+          {`${notification.created_at}前`}
+        </time>
+      </div>
+    </div>
+  </li>
+);
+
+export default NotificationItem;
+
+NotificationItem.propTypes = {
+  notification: PropTypes.shape({
+    message: PropTypes.string,
+    created_at: PropTypes.string,
+    read: PropTypes.bool,
+  }).isRequired,
+  onClick: PropTypes.func.isRequired,
+};

--- a/app/javascript/components/NotificationItem.js
+++ b/app/javascript/components/NotificationItem.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const NotificationItem = ({ notification, onClick }) => (
-  <li className="header-dropdown__item" onClick={() => onClick(notification)}>
+  <li aria-hidden="true" className="header-dropdown__item" onClick={() => onClick(notification)}>
     <div className="header-dropdown__container">
       <div className={`header-dropdown__unread-icon ${notification.read ? 'is-read' : ''}`} />
       <div className="header-dropdown__text-holder">

--- a/app/javascript/components/NotificationList.js
+++ b/app/javascript/components/NotificationList.js
@@ -11,15 +11,19 @@ const NotificationList = ({ onClick, closeDropdown, notifications }) => {
       <div className="header-dropdown__header">
         通知
       </div>
-      <ul className="header-dropdown__items">
-        { notifications.map((notification) => (
-          <NotificationItem
-            notification={notification}
-            onClick={onClick}
-            key={notification.id}
-          />
-        ))}
-      </ul>
+      { notifications.length
+        ? (
+          <ul className="header-dropdown__items">
+            { notifications.map((notification) => (
+              <NotificationItem
+                notification={notification}
+                onClick={onClick}
+                key={notification.id}
+              />
+            ))}
+          </ul>
+        )
+        : <p className="header-dropdown__container">通知はありません</p>}
     </div>
   );
 };

--- a/app/javascript/components/NotificationList.js
+++ b/app/javascript/components/NotificationList.js
@@ -13,7 +13,7 @@ const NotificationList = ({ onClick, closeDropdown, notifications }) => {
       </div>
       { notifications.length
         ? (
-          <ul className="header-dropdown__items">
+          <ul className="header-dropdown__items is-notification">
             { notifications.map((notification) => (
               <NotificationItem
                 notification={notification}

--- a/app/javascript/components/NotificationList.js
+++ b/app/javascript/components/NotificationList.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import onClickOutside from 'react-onclickoutside';
+import NotificationItem from './NotificationItem';
+
+const NotificationList = ({ onClick, closeDropdown, notifications }) => {
+  NotificationList.handleClickOutside = () => closeDropdown();
+
+  return (
+    <div className="header-dropdown is-notification">
+      <div className="header-dropdown__header">
+        通知
+      </div>
+      <ul className="header-dropdown__items">
+        { notifications.map((notification) => (
+          <NotificationItem
+            notification={notification}
+            onClick={onClick}
+            key={notification.id}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+const clickOutsideConfig = {
+  handleClickOutside: () => NotificationList.handleClickOutside,
+};
+
+export default onClickOutside(NotificationList, clickOutsideConfig);
+
+NotificationList.propTypes = {
+  closeDropdown: PropTypes.func.isRequired,
+  onClick: PropTypes.func.isRequired,
+  notifications: PropTypes.arrayOf(PropTypes.object).isRequired,
+};

--- a/app/javascript/components/UserNav.js
+++ b/app/javascript/components/UserNav.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import HeaderMenu from './HeaderMenu';
+import Notification from './Notification';
 
 const UserNav = ({ user }) => (
   <div className="header-nav__items">
+    <div className="header-nav__item">
+      <Notification />
+    </div>
     <div className="header-nav__item">
       <HeaderMenu user={user} />
     </div>

--- a/app/javascript/components/UserNav.js
+++ b/app/javascript/components/UserNav.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import HeaderMenu from './HeaderMenu';
 import Notification from './Notification';
 
-const UserNav = ({ user }) => (
+const UserNav = ({ user, services }) => (
   <div className="header-nav__items">
     <div className="header-nav__item">
-      <Notification />
+      <Notification services={services} />
     </div>
     <div className="header-nav__item">
       <HeaderMenu user={user} />

--- a/app/javascript/components/UserNav.js
+++ b/app/javascript/components/UserNav.js
@@ -18,4 +18,9 @@ export default UserNav;
 
 UserNav.propTypes = {
   user: PropTypes.objectOf(PropTypes.string).isRequired,
+  services: PropTypes.arrayOf(PropTypes.object),
+};
+
+UserNav.defaultProps = {
+  services: [],
 };

--- a/app/javascript/packs/application/app.js
+++ b/app/javascript/packs/application/app.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Header from '../../components/Header';
 
 const App = ({ children }) => (
   <>
-    <Header />
     <div className="container">
       {children}
     </div>

--- a/app/javascript/packs/my_account/edit.js
+++ b/app/javascript/packs/my_account/edit.js
@@ -2,13 +2,17 @@ import React from 'react';
 import { render } from 'react-dom';
 import App from '../application/app';
 import EditUser from '../../components/EditUser';
+import Header from '../../components/Header';
 
 const Edit = () => (
-  <App>
-    <main className="page">
-      <EditUser />
-    </main>
-  </App>
+  <>
+    <Header />
+    <App>
+      <main className="page">
+        <EditUser />
+      </main>
+    </App>
+  </>
 );
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/app/javascript/packs/services/edit.js
+++ b/app/javascript/packs/services/edit.js
@@ -3,13 +3,17 @@ import PropTypes from 'prop-types';
 import { render } from 'react-dom';
 import EditService from '../../components/EditService';
 import App from '../application/app';
+import Header from '../../components/Header';
 
 const Edit = ({ serviceId }) => (
-  <App>
-    <main className="page">
-      <EditService serviceId={serviceId} />
-    </main>
-  </App>
+  <>
+    <Header />
+    <App>
+      <main className="page">
+        <EditService serviceId={serviceId} />
+      </main>
+    </App>
+  </>
 );
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/app/javascript/packs/services/index.js
+++ b/app/javascript/packs/services/index.js
@@ -5,6 +5,7 @@ import Flash from '../../components/Flash';
 import getCsrfToken from '../../helpers/getCsrfToken';
 import TotalPriceList from '../../components/TotalPriceList';
 import App from '../application/app';
+import Header from '../../components/Header';
 
 class Index extends React.Component {
   constructor(props) {
@@ -65,13 +66,16 @@ class Index extends React.Component {
     }
 
     return (
-      <App>
-        <Flash services={services} />
-        <main className="page">
-          <TotalPriceList services={services} />
-          <UsingServices onDelete={this.deleteService} services={services} />
-        </main>
-      </App>
+      <>
+        <Header services={services} />
+        <App>
+          <Flash services={services} />
+          <main className="page">
+            <TotalPriceList services={services} />
+            <UsingServices onDelete={this.deleteService} services={services} />
+          </main>
+        </App>
+      </>
     );
   }
 }

--- a/app/javascript/packs/services/new.js
+++ b/app/javascript/packs/services/new.js
@@ -2,13 +2,17 @@ import React from 'react';
 import { render } from 'react-dom';
 import NewService from '../../components/NewService';
 import App from '../application/app';
+import Header from '../../components/Header';
 
 const New = () => (
-  <App>
-    <main className="page">
-      <NewService />
-    </main>
-  </App>
+  <>
+    <Header />
+    <App>
+      <main className="page">
+        <NewService />
+      </main>
+    </App>
+  </>
 );
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Notification < ApplicationRecord
+end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -2,4 +2,6 @@
 
 class Notification < ApplicationRecord
   belongs_to :service
+
+  scope :recent, -> { order(created_at: :desc).limit(10) }
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Notification < ApplicationRecord
+  belongs_to :service
 end

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -4,4 +4,12 @@ class Notification < ApplicationRecord
   belongs_to :service
 
   scope :recent, -> { order(created_at: :desc).limit(10) }
+
+  def self.renew_service(service)
+    Notification.create!(
+      service: service,
+      read: false,
+      message: "「#{service.name}」が更新されました。\n次回の更新日は#{I18n.l service.next_renewed_on(1)}です。"
+    )
+  end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -2,6 +2,7 @@
 
 class Service < ApplicationRecord
   enum plan: { monthly: 0, yearly: 1 }
+  has_many :notifications, dependent: :destroy
   belongs_to :user
 
   validates :name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :services, dependent: :destroy
+  has_many :notifications, through: :services
 
   validates :password, length: { minimum: 6 }, confirmation: true, if: :password_required?
   validates :password_confirmation, presence: true, if: :password_required?

--- a/app/views/api/notifications/index.json.jbuilder
+++ b/app/views/api/notifications/index.json.jbuilder
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+json.array! @notifications do |notification|
+  json.id notification.id
+  json.read notification.read
+  json.message notification.message
+  json.created_at time_ago_in_words notification.created_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  namespace :api do
+    resources :notifications, only: %i(index update)
+  end
   root to: "home#index"
   resources :services, only: %i(index new create edit update destroy)
   resource :my_account, only: %i(show edit update), controller: "my_account"

--- a/db/migrate/20200714060150_create_notifications.rb
+++ b/db/migrate/20200714060150_create_notifications.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CreateNotifications < ActiveRecord::Migration[6.0]
+  def change
+    create_table :notifications do |t|
+      t.references :service, null: false, foreign_key: true
+      t.boolean :read, default: false, null: false
+      t.string :message
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,9 +12,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_14_013020) do
+ActiveRecord::Schema.define(version: 2020_07_14_060150) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "notifications", force: :cascade do |t|
+    t.bigint "service_id", null: false
+    t.boolean "read", default: false, null: false
+    t.string "message"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["service_id"], name: "index_notifications_on_service_id"
+  end
 
   create_table "services", force: :cascade do |t|
     t.string "name", null: false
@@ -41,5 +50,6 @@ ActiveRecord::Schema.define(version: 2020_07_14_013020) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "notifications", "services"
   add_foreign_key "services", "users"
 end

--- a/lib/tasks/notification.rake
+++ b/lib/tasks/notification.rake
@@ -5,6 +5,7 @@ namespace :notification do
   task renewal: :environment do
     Service.includes(:user).renewal.group_by(&:user).each do |user, services|
       unless user.renewal_sent_at.try(:between?, Date.today.beginning_of_day, Date.today.end_of_day)
+        services.each { |service| Notification.renew_service(service) }
         UserMailer.renew_services(user, services).deliver_now
         user.touch(:renewal_sent_at)
       end


### PR DESCRIPTION
ref #16 

## 概要

### NotificationモデルとAPIの作成

- Notificationモデルを作成
    - 最新10件を取得するスコープを定義
    - UserやServiceとの関連付けを定義
    - Rakeタスクから利用できるように通知を作成するメソッドを定義した(`renew_service`)
- APIの作成
    - jsonデータの作成について、通知の作成時刻を`time_ago_in_words`を利用して表示させるために、jbuilderを利用した
        - ライブラリを利用するより簡潔ではないかと考えた

### 通知コンポーネントの作成

- 通知を表示するためのコンポーネントを作成
    - それぞれの通知をクリックした時に既読状態にするため、クリック時のイベントハンドラとしてmarkAsRead()を定義
    - 未読通知があることがアイコンを見てわかるように、未読マークを表示させるようにした
    - 開いた通知欄についても未読の通知にはマークがつくようになっている
    - 通知欄の範囲外をクリックした時に自動的に閉じるようにonClickOutsideライブラリを利用
        - コンポーネントの範囲外で起きたイベントは'mousedown'と'touchstart'がデフォルトだが、'mousedown'では通知アイコンをクリックした時に再度通知欄が開かれてしまったため、'click'をeventTypeとするように修正した

### スタイルの定義

- スタイルの作成
    - 基本的には元の実装のものを利用しているが、一部変更した
        - 通知欄について、件数が増えると通知欄が縦に大きくなってしまうため、heightを制限し、スクロールできるようにした

### Rakeタスクの修正

- タスクを走らせた際にメール通知とともに通知を作成するため、RakeタスクにNotificationを作成する処理を追加

### バグの修正

- サービスに紐付いた通知が作成された後に該当サービスを削除し、通知欄から該当サービスの通知をクリックするとエラーが出力される。
    - Headerコンポーネントへとservicesの状態を渡せるようにし、componentDidUpdateを用いてservicesの状態に変更があった時に、再度Notificationをfetchするようにした

## スクリーンショット

[![Image from Gyazo](https://i.gyazo.com/1455547f4bace501cbf30a02f2ec74a4.png)](https://gyazo.com/1455547f4bace501cbf30a02f2ec74a4)