### PR TITLE
1単語の文字数の多いメモがメモ欄からはみ出てしまっていたのを修正

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -238,6 +238,7 @@ img {
     padding: 1rem 5px;
     font-size: .895rem;
     white-space: pre-line;
+    word-break: break-all;
   }
 }
 

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -238,7 +238,7 @@ img {
     padding: 1rem 5px;
     font-size: .895rem;
     white-space: pre-line;
-    word-break: break-all;
+    overflow-wrap: break-word;
   }
 }
 


### PR DESCRIPTION
## 概要

- サービスのメモについて、1単語の文字数が多い場合、表示スペースからはみ出てしまっていたのを修正した
    - 文字数の多いURLを添付した場合などにはみ出ることを確認したため、単語の区切りを問わず表示範囲内で改行するように修正した

## スクリーンショット

before:

[![Image from Gyazo](https://i.gyazo.com/3e669e0336a1a9c07851efa6caf265b9.png)](https://gyazo.com/3e669e0336a1a9c07851efa6caf265b9)

after:

[![Image from Gyazo](https://i.gyazo.com/b706e538a33a9f4f9e488f001c2dac21.png)](https://gyazo.com/b706e538a33a9f4f9e488f001c2dac21)