### PR TITLE
スタイルの追加

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -666,3 +666,30 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   opacity: 0;
   cursor: pointer;
 }
+
+// errors
+
+.errors {
+  border: 1px solid #db2828;
+  border-radius: 4px;
+  max-width: 30rem;
+  margin-right: auto;
+  margin-left: auto;
+  margin-bottom: 2rem;
+  background-color: #fff6f6;
+  padding: 1rem;
+}
+
+.errors__title {
+  color: #9f3a38;
+  font-size: 1rem;
+  text-align: center;
+  margin-bottom: .5rem;
+}
+
+.errors__item {
+  color: #9f3a38;
+  list-style: none;
+  font-size: .875rem;
+  margin-bottom: 2px;
+}

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -492,3 +492,177 @@ header > .container {
   padding-right: .5rem;
   padding-left: .25rem;
 }
+
+// form
+
+.form-items {
+  margin: 0 auto;
+  max-width: 37.5rem;
+}
+
+.form-items__inner {
+  max-width: 18.5rem;
+  max-width: -webkit-fit-content;
+}
+
+.form-item__inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.form-item {
+  margin-bottom: 1.5rem;
+  display: flex;
+  align-items: center;
+  &--checkbox {
+    align-items: center;
+    order: 1;
+  }
+}
+
+.form-item__help {
+  margin-top: .2rem;
+  font-size: .75rem;
+}
+
+.form-item__link {
+  font-size: 0.8rem;
+}
+
+.form-item--block {
+  margin-bottom: 1.5rem;
+  &:last-of-type {
+    margin-bottom: 0;
+  }
+}
+
+.form-item__label {
+  font-size: 0.875rem;
+  margin-right: 2rem;
+  min-width: 5rem;
+  text-align: right;
+  &--checkbox {
+    font-weight: 600;
+    font-size: 0.875rem;
+    cursor: pointer;
+  }
+}
+
+.form-item__label--block {
+  font-weight: 600;
+  font-size: 0.875rem;
+  display: block;
+  margin-bottom: .2rem;
+}
+
+.form-item__text-input {
+  border: 1px solid rgba(34 ,36 ,38 , .15);
+  border-radius: .25rem;
+  padding: .45rem;
+  font-size: .875rem;
+  color: black;
+  flex: 1 1 auto;
+  &--select {
+    @extend .form-item__text-input;
+    outline: none;
+    &:focus {
+      border-bottom-left-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+}
+
+.form-item__text-input--block {
+  border: 1px solid rgba(34 ,36 ,38 , .15);
+  border-radius: .25rem;
+  padding: .45rem;
+  font-size: .875rem;
+  color: black;
+  width: 100%;
+}
+
+.form-item__select {
+  padding: .45rem 2rem .45rem .45rem;
+  font-size: .875rem;
+  color: black;
+  width: 100%;
+  z-index: 1;
+  position: relative;
+  cursor: pointer;
+}
+
+.is-select {
+  position: relative;
+  border: 1px solid rgba(34, 36, 38, .15);
+  border-radius: .25rem;
+  flex: 1 1 auto;
+  &:hover {
+    border: 1px solid rgba(34, 36, 38, .3);
+    border-radius: .25rem;
+  }
+}
+
+.is-select::before {
+  font-weight: 900;
+  content: "⌵";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+}
+
+.form-item__textarea {
+  border: 1px solid rgba(34, 36, 38, .15);
+  border-radius: .25rem;
+  padding: .45rem;
+  font-size: .875rem;
+  color: black;
+  min-height: 5rem;
+  height: 6rem;
+  resize: vertical;
+  flex: 1 1 auto;
+}
+
+.form-actions__items {
+  list-style: none;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 1.5rem 0;
+}
+
+.form-actions__item {
+  padding: 0 .5rem;
+  min-width: 12rem;
+}
+
+.form-actions__item--cancel {
+  padding: 0 .5rem;
+}
+
+input[type="date"]::-webkit-inner-spin-button{
+  -webkit-appearance: none;
+}
+
+input[type="date"]::-webkit-clear-button{
+  position: relative;
+  z-index: 1;
+}
+
+input[type="date"] {
+  position: relative;
+}
+
+input[type="date"]::-webkit-calendar-picker-indicator {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  cursor: pointer;
+}

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -693,3 +693,40 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   font-size: .875rem;
   margin-bottom: 2px;
 }
+
+// card
+
+.card-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  margin-bottom: 2.5rem;
+}
+
+.card {
+  border-radius: 3px;
+  flex: 0 0 45%;
+  &--yellow {
+    background-color: #f6932b;
+  }
+  &--green {
+    background-color: #35AB45;
+  }
+}
+
+.card__body {
+  padding: .5rem;
+}
+
+.card__amount {
+  color: white;
+  font-size: 1.5rem;
+  text-align: center;
+}
+
+.card__title {
+  color: white;
+  font-size: .75rem;
+  text-align: center;
+  user-select: none;
+}

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -730,3 +730,24 @@ input[type="date"]::-webkit-calendar-picker-indicator {
   text-align: center;
   user-select: none;
 }
+
+// flash
+
+.flash {
+  padding: .5rem 0;
+}
+
+.flash__message {
+  text-align: center;
+  font-size: .9rem;
+}
+
+.flash--notice {
+  background-color: #46a91c;
+  color: white;
+}
+
+.flash--alert {
+  background-color: #d64242;
+  color: white;
+}

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -211,6 +211,7 @@ img {
 .list__labels {
   display: flex;
   padding: 0 1.5rem;
+  margin-bottom: 1rem;
 }
 
 .list__label {

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -227,6 +227,10 @@ img {
   }
 }
 
+.list-label__button {
+  width: 24px;
+}
+
 // list item
 
 .list-item {

--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -53,6 +53,11 @@ img {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.page-header__title {
+  font-size: 1.3rem;
 }
 
 .page-header__action {

--- a/app/javascript/components/EditService.js
+++ b/app/javascript/components/EditService.js
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ServiceForm from './ServiceForm';
 import getCsrfToken from '../helpers/getCsrfToken';
+import PageHeader from './PageHeader';
+import PageHeaderTitle from './PageHeaderTitle';
+import LinkButton from './LinkButton';
 
 class EditService extends React.Component {
   constructor(props) {
@@ -65,6 +68,12 @@ class EditService extends React.Component {
 
     return (
       <div>
+        <PageHeader>
+          <PageHeaderTitle>サービス修正</PageHeaderTitle>
+          <div className="page-header__action">
+            <LinkButton href="/" color="secondary" size="md">一覧</LinkButton>
+          </div>
+        </PageHeader>
         <ServiceForm
           service={service}
           onSubmit={this.updateService}

--- a/app/javascript/components/ListLabels.js
+++ b/app/javascript/components/ListLabels.js
@@ -8,6 +8,7 @@ const ListLabels = () => (
     <ListLabelItem colSize="sm">料金</ListLabelItem>
     <ListLabelItem>更新日</ListLabelItem>
     <ListLabelItem>通知日</ListLabelItem>
+    <div className="list-label__button" />
   </div>
 );
 

--- a/app/javascript/components/NewService.js
+++ b/app/javascript/components/NewService.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import ServiceForm from './ServiceForm';
 import getCsrfToken from '../helpers/getCsrfToken';
+import PageHeader from './PageHeader';
+import PageHeaderTitle from './PageHeaderTitle';
+import LinkButton from './LinkButton';
 
 class NewService extends React.Component {
   constructor(props) {
@@ -42,6 +45,12 @@ class NewService extends React.Component {
     const { errorMessages } = this.state;
     return (
       <div>
+        <PageHeader>
+          <PageHeaderTitle>サービス登録</PageHeaderTitle>
+          <div className="page-header__action">
+            <LinkButton href="/" color="secondary" size="md">一覧</LinkButton>
+          </div>
+        </PageHeader>
         <ServiceForm
           onSubmit={this.createService}
           errorMessages={errorMessages}

--- a/app/javascript/components/ServiceForm.js
+++ b/app/javascript/components/ServiceForm.js
@@ -50,24 +50,22 @@ class ServiceForm extends React.Component {
 
         <form onSubmit={this.handleSubmit} id="service-form">
           <div className="form-items">
-            <div className="form-item">
-              <label htmlFor="service_name">
-                <strong className="form-item__label">サービス名</strong>
-                <input
-                  type="text"
-                  className="form-item__text-input"
-                  id="service_name"
-                  name="name"
-                  placeholder="サービス名"
-                  value={service.name}
-                  onChange={this.handleInputChange}
-                />
-              </label>
-            </div>
+            <label htmlFor="service_name" className="form-item">
+              <strong className="form-item__label">サービス名</strong>
+              <input
+                type="text"
+                className="form-item__text-input"
+                id="service_name"
+                name="name"
+                placeholder="サービス名"
+                value={service.name}
+                onChange={this.handleInputChange}
+              />
+            </label>
             <div className="form-items__inner">
-              <div className="form-item">
-                <label htmlFor="service_plan">
-                  <strong className="form-item__label">プラン</strong>
+              <label htmlFor="service_plan" className="form-item">
+                <strong className="form-item__label">プラン</strong>
+                <div className="is-select">
                   <select
                     name="plan"
                     id="service_plan"
@@ -78,60 +76,52 @@ class ServiceForm extends React.Component {
                     <option value="monthly">月額</option>
                     <option value="yearly">年額</option>
                   </select>
-                </label>
-              </div>
-              <div className="form-item">
-                <label htmlFor="service_price">
-                  <strong className="form-item__label">料金</strong>
-                  <input
-                    type="number"
-                    className="form-item__text-input"
-                    id="service_price"
-                    name="price"
-                    value={service.price}
-                    onChange={this.handleInputChange}
-                  />
-                </label>
-              </div>
-            </div>
-            <div className="form-item">
-              <label htmlFor="service_renewed_on">
-                <strong className="form-item__label">更新日</strong>
+                </div>
+              </label>
+              <label htmlFor="service_price" className="form-item">
+                <strong className="form-item__label">料金</strong>
                 <input
-                  type="date"
+                  type="number"
                   className="form-item__text-input"
-                  id="service_renewed_on"
-                  name="renewed_on"
-                  value={service.renewed_on}
+                  id="service_price"
+                  name="price"
+                  value={service.price}
                   onChange={this.handleInputChange}
                 />
               </label>
             </div>
-            <div className="form-item">
-              <label htmlFor="service_remind_on">
-                <strong className="form-item__label">通知日</strong>
-                <input
-                  type="date"
-                  className="form-item__text"
-                  id="service_remind_on"
-                  name="remind_on"
-                  value={service.remind_on}
-                  onChange={this.handleInputChange}
-                />
-              </label>
-            </div>
-            <div className="form-item">
-              <label htmlFor="service_description">
-                <strong className="form-item__label">メモ</strong>
-                <textarea
-                  name="description"
-                  id="service_description"
-                  className="form-item__textarea"
-                  value={service.description}
-                  onChange={this.handleInputChange}
-                />
-              </label>
-            </div>
+            <label htmlFor="service_renewed_on" className="form-item">
+              <strong className="form-item__label">更新日</strong>
+              <input
+                type="date"
+                className="form-item__text-input"
+                id="service_renewed_on"
+                name="renewed_on"
+                value={service.renewed_on}
+                onChange={this.handleInputChange}
+              />
+            </label>
+            <label htmlFor="service_remind_on" className="form-item">
+              <strong className="form-item__label">通知日</strong>
+              <input
+                type="date"
+                className="form-item__text-input"
+                id="service_remind_on"
+                name="remind_on"
+                value={service.remind_on}
+                onChange={this.handleInputChange}
+              />
+            </label>
+            <label htmlFor="service_description" className="form-item">
+              <strong className="form-item__label">メモ</strong>
+              <textarea
+                name="description"
+                id="service_description"
+                className="form-item__textarea"
+                value={service.description}
+                onChange={this.handleInputChange}
+              />
+            </label>
           </div>
           <ul className="form-actions__items">
             <li className="form-actions__item">


### PR DESCRIPTION
## 概要

実装時に追加できていなかったスタイルを追加
元の実装のものを利用

 - フォーム(ユーザー登録/修正、サービス登録/修正、ログイン)
     - 各入力項目を囲んでいたdivタグは不要だったため、削除し、label要素にスタイルを適用した
 - 利用料金の表示カード
 - Flashメッセージ
 - バリデーションエラーメッセージ

## スクリーンショット

元の実装と同じですが、一応貼っておきます。

トップページ

[![Image from Gyazo](https://i.gyazo.com/f121a6ea69b355334a0e497b69531f22.png)](https://gyazo.com/f121a6ea69b355334a0e497b69531f22)

アカウント作成

[![Image from Gyazo](https://i.gyazo.com/8538d4c440587138efe1e6036b067760.png)](https://gyazo.com/8538d4c440587138efe1e6036b067760)

ログイン

[![Image from Gyazo](https://i.gyazo.com/f80839661ec6876ae29973c4929fbf1a.png)](https://gyazo.com/f80839661ec6876ae29973c4929fbf1a)

サービス入力フォーム

[![Image from Gyazo](https://i.gyazo.com/57efa1361b1422f6f37ffd1727b95f1a.png)](https://gyazo.com/57efa1361b1422f6f37ffd1727b95f1a)