### PR TITLE
PropTypesの警告を解消

### DIFF
--- a/app/javascript/components/ListDisplayedItem.js
+++ b/app/javascript/components/ListDisplayedItem.js
@@ -28,11 +28,7 @@ ListDisplayedItem.propTypes = {
     renewed_on: PropTypes.string,
     next_renewed_on: PropTypes.string,
     remind_on: PropTypes.string,
-  }),
+  }).isRequired,
   onClick: PropTypes.func.isRequired,
   isExpand: PropTypes.bool.isRequired,
-};
-
-ListDisplayedItem.defaultProps = {
-  service: undefined,
 };

--- a/app/javascript/components/ServiceForm.js
+++ b/app/javascript/components/ServiceForm.js
@@ -97,7 +97,7 @@ class ServiceForm extends React.Component {
                 className="form-item__text-input"
                 id="service_renewed_on"
                 name="renewed_on"
-                value={service.renewed_on}
+                value={service.renewed_on || ''}
                 onChange={this.handleInputChange}
               />
             </label>
@@ -108,7 +108,7 @@ class ServiceForm extends React.Component {
                 className="form-item__text-input"
                 id="service_remind_on"
                 name="remind_on"
-                value={service.remind_on}
+                value={service.remind_on || ''}
                 onChange={this.handleInputChange}
               />
             </label>

--- a/app/javascript/components/ServiceItem.js
+++ b/app/javascript/components/ServiceItem.js
@@ -43,10 +43,6 @@ ServiceItem.propTypes = {
     renewed_on: PropTypes.string,
     remind_on: PropTypes.string,
     description: PropTypes.string,
-  }),
+  }).isRequired,
   onDelete: PropTypes.func.isRequired,
-};
-
-ServiceItem.defaultProps = {
-  service: undefined,
 };

--- a/app/javascript/components/ServiceItemElement.js
+++ b/app/javascript/components/ServiceItemElement.js
@@ -12,9 +12,10 @@ ServiceItemElement.propTypes = {
   children: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,
-  ]).isRequired,
+  ]),
 };
 
 ServiceItemElement.defaultProps = {
   size: 'md',
+  children: null,
 };

--- a/app/javascript/packs/application/app.js
+++ b/app/javascript/packs/application/app.js
@@ -12,5 +12,7 @@ const App = ({ children }) => (
 export default App;
 
 App.propTypes = {
-  children: PropTypes.arrayOf(PropTypes.element).isRequired,
+  children: PropTypes.oneOfType(
+    [PropTypes.element, PropTypes.arrayOf(PropTypes.element)],
+  ).isRequired,
 };

--- a/app/javascript/packs/application/welcome.js
+++ b/app/javascript/packs/application/welcome.js
@@ -16,5 +16,7 @@ const Welcome = ({ children }) => (
 export default Welcome;
 
 Welcome.propTypes = {
-  children: PropTypes.element.isRequired,
+  children: PropTypes.oneOfType(
+    [PropTypes.element, PropTypes.arrayOf(PropTypes.element)],
+  ).isRequired,
 };


### PR DESCRIPTION
## 概要

これまでの実装時に設定していたPropTypesが開発が進むにつれて警告を受けるようになった
以下の警告を解消するように修正。
結果、PropTypeの警告は0となった。

### ServiceForm.js

ServiceForm.jsが受け取るpropsについて、サービス修正ページにアクセスした時に、renewed_on, remind_onのいずれかが未入力の場合、nullがvalueとして設定される。
valueの値がnullの場合に警告を受けるので、valueがnullの時には空文字となるように修正した

### ServiceItemElement.js

ServiceItemElement.jsが受け取るpropsについて、未入力の項目がある場合に警告が出力されてしまっていた。
上同様、renewed_on, remind_onがnullとなるケースがあり、「childrenを渡すことは必須としたいが、nullのケースがある」ことをうまく設定できなかったため、defaultPropsを定義することで回避した

### app.js/welcome.js

app.jsとwelcome.jsについては、1つ以上のコンポーネントが渡されているため、そのようにPropTypesを定義し直すことで警告を解消した

### その他

serviceが渡されることが必須であることが明白なコンポーネントについては、isRequiredを追加した

## 注意事項

アプリ内通知を作成した時点での警告状態を確認したかったため、#63 からブランチを切りました。
マージは#63がマージされてからの方が良さそうです。