### PR TITLE
ログイン失敗時に表示されるエラーメッセージを修正

### DIFF
--- a/app/javascript/components/Login.js
+++ b/app/javascript/components/Login.js
@@ -31,7 +31,7 @@ class Login extends React.Component {
         if (response.ok) {
           window.location.href = '/';
         } else {
-          window.message = { alert: 'ユーザー名かパスワードが正しくありません。' };
+          window.message = { alert: 'メールアドレスかパスワードが正しくありません。' };
           this.setState({ hasError: true });
         }
       })


### PR DESCRIPTION
## 概要

ログインに失敗した時に表示されるエラーメッセージの文言を修正

- メールアドレスとパスワードを入力してログインするが、エラーメッセージには「ユーザー名かパスワードが正しくありません」と表示されてしまっていた。
    - 「メールアドレスかパスワードが正しくありません」と表示されるように文言を修正